### PR TITLE
fix sms shortcode parameter setting

### DIFF
--- a/src/Twilio.Api.Silverlight/Sms.Async.cs
+++ b/src/Twilio.Api.Silverlight/Sms.Async.cs
@@ -121,7 +121,7 @@ namespace Twilio
 
 			var request = new RestRequest();
 			request.Resource = "Accounts/{AccountSid}/SMS/ShortCodes/{ShortCodeSid}";
-			request.AddParameter("ShortCodeSid", shortCodeSid);
+			request.AddUrlSegment("ShortCodeSid", shortCodeSid);
 
 			ExecuteAsync<SMSShortCode>(request, (response) => callback(response));
 		}
@@ -144,7 +144,7 @@ namespace Twilio
 
 			var request = new RestRequest();
 			request.Resource = "Accounts/{AccountSid}/SMS/ShortCodes/{ShortCodeSid}";
-			request.AddParameter("ShortCodeSid", shortCodeSid);
+			request.AddUrlSegment("ShortCodeSid", shortCodeSid);
 
 			if (friendlyName.HasValue()) request.AddParameter("FriendlyName", friendlyName);
 			if (apiVersion.HasValue()) request.AddParameter("ApiVersion", apiVersion);

--- a/src/Twilio.Api/Sms.cs
+++ b/src/Twilio.Api/Sms.cs
@@ -121,7 +121,7 @@ namespace Twilio
 
 			var request = new RestRequest();
 			request.Resource = "Accounts/{AccountSid}/SMS/ShortCodes/{ShortCodeSid}";
-			request.AddParameter("ShortCodeSid", shortCodeSid);
+			request.AddUrlSegment("ShortCodeSid", shortCodeSid);
 
 			return Execute<SMSShortCode>(request);
 		}
@@ -143,7 +143,7 @@ namespace Twilio
 
 			var request = new RestRequest();
 			request.Resource = "Accounts/{AccountSid}/SMS/ShortCodes/{ShortCodeSid}";
-			request.AddParameter("ShortCodeSid", shortCodeSid);
+			request.AddUrlSegment("ShortCodeSid", shortCodeSid);
 
 			if (friendlyName.HasValue()) request.AddParameter("FriendlyName", friendlyName);
 			if (apiVersion.HasValue()) request.AddParameter("ApiVersion", apiVersion);


### PR DESCRIPTION
Changed how the ShortCodeSid value is being set so that RestSharp will properly pick it up.
