### PR TITLE
Fix TwilioRestClient.ListShortCodes (in Sms.cs)

### DIFF
--- a/src/Twilio.Api/Sms.cs
+++ b/src/Twilio.Api/Sms.cs
@@ -143,7 +143,7 @@ namespace Twilio
 		public SmsShortCodeResult ListShortCodes(string shortCode, string friendlyName)
 		{
 			var request = new RestRequest();
-			request.Resource = "Accounts/{AccountSid}/SMS/ShortCodes}.json";
+			request.Resource = "Accounts/{AccountSid}/SMS/ShortCodes.json";
 
 			if (shortCode.HasValue()) request.AddParameter("ShortCode", shortCode);
 			if (friendlyName.HasValue()) request.AddParameter("FriendlyName", friendlyName);


### PR DESCRIPTION
api call was failing because of a typo
