### PR TITLE
s/CurrentPosition/Position

### DIFF
--- a/src/Twilio.Api/Model/QueueMember.cs
+++ b/src/Twilio.Api/Model/QueueMember.cs
@@ -25,6 +25,6 @@ namespace Twilio
         /// <summary>
         /// The callers current position in the Queue
         /// </summary>
-        public int? CurrentPosition { get; set; }
+        public int? Position { get; set; }
     }
 }


### PR DESCRIPTION
In this case the Member API returns "position" and not "CurrentPosition" which means that this variable will always be empty.
