### PR TITLE
in the comments, removed references to the sort order of list resources.

### DIFF
--- a/src/Twilio.Api/Calls.cs
+++ b/src/Twilio.Api/Calls.cs
@@ -8,7 +8,6 @@ namespace Twilio
 	{
 		/// <summary>
 		/// Returns a paged list of phone calls made to and from the account.
-		/// Sorted by DateUpdated with most-recent calls first.
 		/// Makes a GET request to the Calls List resource.
 		/// </summary>
 		public CallResult ListCalls()
@@ -21,7 +20,6 @@ namespace Twilio
 
 		/// <summary>
 		/// Returns a paged list of phone calls made to and from the account.
-		/// Sorted by DateUpdated with most-recent calls first.
 		/// Makes a GET request to the Calls List resource.
 		/// </summary>
 		/// <param name="options">List filter options. If an property is set the list will be filtered by that value.</param>

--- a/src/Twilio.Api/Conference.cs
+++ b/src/Twilio.Api/Conference.cs
@@ -6,7 +6,7 @@ namespace Twilio
 	{
 		/// <summary>
 		/// Returns a list of conferences within an account. 
-		/// The list includes paging information and is sorted by DateUpdated, with most recent conferences first.
+		/// The list includes paging information.
 		/// Makes a GET request to the Conferences List resource.
 		/// </summary>
 		public ConferenceResult ListConferences()
@@ -19,7 +19,7 @@ namespace Twilio
 
 		/// <summary>
 		/// Returns a list of conferences within an account. 
-		/// The list includes paging information and is sorted by DateUpdated, with most recent conferences first.
+		/// The list includes paging information.
 		/// Makes a POST request to the Conferences List resource.
 		/// </summary>
 		/// <param name="options">List filter options. Only properties with values are included in request.</param>

--- a/src/Twilio.Api/Notifications.cs
+++ b/src/Twilio.Api/Notifications.cs
@@ -22,7 +22,7 @@ namespace Twilio
 
 		/// <summary>
 		/// Returns a list of notifications generated for an account. 
-		/// The list includes paging information and is sorted by DateUpdated, with most recent notifications first.
+		/// The list includes paging information.
 		/// Makes a GET request to a Notifications List resource.
 		/// </summary>
 		public NotificationResult ListNotifications()
@@ -32,7 +32,7 @@ namespace Twilio
 
 		/// <summary>
 		/// Returns a filtered list of notifications generated for an account. 
-		/// The list includes paging information and is sorted by DateUpdated, with most recent notifications first.
+		/// The list includes paging information.
 		/// Makes a GET request to a Notifications List resource.
 		/// </summary>
 		/// <param name="log">Only show notifications for this log, using the integer log values: 0 is ERROR, 1 is WARNING</param>

--- a/src/Twilio.Api/Sms.cs
+++ b/src/Twilio.Api/Sms.cs
@@ -23,7 +23,7 @@ namespace Twilio
 
 		/// <summary>
 		/// Returns a list of SMS messages. 
-		/// The list includes paging information and is sorted by DateSent, with most recent messages first.
+		/// The list includes paging information.
 		/// Makes a GET request to the SMSMessage List resource.
 		/// </summary>
 		public SmsMessageResult ListSmsMessages()
@@ -32,7 +32,7 @@ namespace Twilio
 		}
 
 		/// <summary>
-		/// Returns a filtered list of SMS messages. The list includes paging information and is sorted by DateSent, with most recent messages first.
+		/// Returns a filtered list of SMS messages. The list includes paging information.
 		/// Makes a GET request to the SMSMessages List resource.
 		/// </summary>
 		/// <param name="to">(Optional) The phone number of the message recipient</param>

--- a/src/Twilio.Api/Transcriptions.cs
+++ b/src/Twilio.Api/Transcriptions.cs
@@ -7,7 +7,7 @@ namespace Twilio
 	public partial class TwilioRestClient
 	{
 		/// <summary>
-		/// Returns a set of Transcriptions that includes paging information, sorted by 'DateUpdated', with most recent transcripts first.
+		/// Returns a set of Transcriptions that includes paging information.
 		/// Makes a GET request to the Transcriptions List resource.
 		/// </summary>
 		public TranscriptionResult ListTranscriptions()
@@ -16,7 +16,7 @@ namespace Twilio
 		}
 
 		/// <summary>
-		/// Returns a paged set of Transcriptions that includes paging information, sorted by 'DateUpdated', with most recent transcripts first.
+		/// Returns a paged set of Transcriptions that includes paging information.
 		/// Makes a GET request to the Transcriptions List resource.
 		/// </summary>
 		/// <param name="pageNumber">The page to start retrieving results from</param>
@@ -32,8 +32,8 @@ namespace Twilio
 		}
 
 		/// <summary>
-		/// Returns a set of Transcriptions for a specific recording that includes paging information, sorted by 'DateUpdated',
-		/// with most recent transcripts first. Makes a GET request to a Recording Transcriptions List resource.
+		/// Returns a set of Transcriptions for a specific recording that includes paging information.
+		/// Makes a GET request to a Recording Transcriptions List resource.
 		/// </summary>
 		/// <param name="recordingSid">The Sid of the recording to retrieve transcriptions for</param>
 		/// <param name="pageNumber">The page to start retrieving results from</param>


### PR DESCRIPTION
For list resources, the order will be switching from DateModified or DateSent, to the id. The id sort will be close to the date/time created sort but may not always be exact. When the behavior is implemented across all accounts, we should add this into the documentation, but until then the references to sort order should be removed.
