### PR TITLE
Fix for exception when using Twilio.Mvc with T4MVC

### DIFF
--- a/src/Twilio.Mvc/TwiMLResult.cs
+++ b/src/Twilio.Mvc/TwiMLResult.cs
@@ -29,7 +29,8 @@ namespace Twilio.TwiML.Mvc
 
 		public TwiMLResult(TwilioResponse response)
 		{
-			data = response.ToXDocument();
+			if (response != null)
+				data = response.ToXDocument();
 		}
 
 		public override void ExecuteResult(ControllerContext controllerContext)


### PR DESCRIPTION
T4MVC tries using the TwilioResponse constructor for the TwiMLResult object when generating the URL using URL.Action which causes a Runtime Exception.

More details can be found at https://t4mvc.codeplex.com/workitem/22
