### PR TITLE
Fixes CallOptions SIP authentication

### DIFF
--- a/src/Twilio.Api.Silverlight/Calls.Async.cs
+++ b/src/Twilio.Api.Silverlight/Calls.Async.cs
@@ -145,6 +145,8 @@ namespace Twilio
 			if (options.IfMachine.HasValue()) request.AddParameter("IfMachine", options.IfMachine);
 			if (options.Timeout.HasValue) request.AddParameter("Timeout", options.Timeout.Value);
 			if (options.Record) request.AddParameter("Record", "true");
+			if (options.SipAuthUsername.HasValue()) request.AddParameter("SipAuthUsername", options.SipAuthUsername);
+			if (options.SipAuthPassword.HasValue()) request.AddParameter("SipAuthPassword", options.SipAuthPassword);
 		}
 
 		/// <summary>

--- a/src/Twilio.Api/Model/CallOptions.cs
+++ b/src/Twilio.Api/Model/CallOptions.cs
@@ -63,11 +63,11 @@ namespace Twilio
 		/// If this is a Sip call, set the authorization username for your Sip
 		/// endpoint
 		/// </summary>
-		public bool SipAuthUsername { get; set; }
+		public string SipAuthUsername { get; set; }
 		/// <summary>
 		/// If this is a Sip call, set the authorization password for your Sip
 		/// endpoint
 		/// </summary>
-		public bool SipAuthPassword { get; set; }
+		public string SipAuthPassword { get; set; }
 	}
 }


### PR DESCRIPTION
I have updated CallOptions - SipAuthUsername and SipAuthPassword are strings and they are included in the AddCallOptions method.

According to Twilio docs:
Example 2 shows that properties should be of type string and the intended usage:
http://www.twilio.com/docs/api/rest/sip#example-2
Optional parameters section describes the parameters.
http://www.twilio.com/docs/api/rest/sip#post-parameters-optional
