### PR TITLE
Set the timeout to slightly higher than the Twilio timeout

### DIFF
--- a/src/Twilio.Api/Core.cs
+++ b/src/Twilio.Api/Core.cs
@@ -45,8 +45,9 @@ namespace Twilio
 			_client = new RestClient();
 			_client.UserAgent = "twilio-csharp/" + version; 
 			_client.Authenticator = new HttpBasicAuthenticator(AccountSid, AuthToken);
-            _client.AddDefaultHeader("Accept-charset", "utf-8");
-            _client.BaseUrl = string.Format("{0}{1}", BaseUrl, ApiVersion);
+			_client.AddDefaultHeader("Accept-charset", "utf-8");
+			_client.BaseUrl = string.Format("{0}{1}", BaseUrl, ApiVersion);
+			_client.Timeout = 3050;
 
 			// if acting on a subaccount, use request.AddUrlSegment("AccountSid", "value")
 			// to override for that request.


### PR DESCRIPTION
The Twilio API will time out after 30 seconds, this should ensure that clients aren't hanging around for much longer than that.

I haven't tested this as testing is tricky on a Mac but I read the RestSharp docs and it should work.

Ultimately this should be configurable by clients with a default of 3050 but that is probably for the next iteration of the library.
