### PR TITLE
Fix Client Timeout - Was 3.05 Seconds, Needs To Be 30.5 Seconds To Allow For The Twilio Server To Timeout - The Unit Is Milliseconds

### DIFF
--- a/src/Twilio.Api/Core.cs
+++ b/src/Twilio.Api/Core.cs
@@ -73,7 +73,7 @@ namespace Twilio
 #endif
 
             _client.BaseUrl = string.Format("{0}{1}", BaseUrl, ApiVersion);
-            _client.Timeout = 3050;
+            _client.Timeout = 30500;
 
             // if acting on a subaccount, use request.AddUrlSegment("AccountSid", "value")
             // to override for that request.


### PR DESCRIPTION
As mentioned in https://github.com/twilio/twilio-csharp/pull/97, splitting this PR up.
