### PR TITLE
Updated method AddConferenceListOptions

### DIFF
--- a/src/Twilio.WinRT/Conference.cs
+++ b/src/Twilio.WinRT/Conference.cs
@@ -200,7 +200,7 @@ namespace Twilio
 
         private void AddConferenceListOptions(ConferenceListRequest options, RestRequest request)
         {
-            if (options.Status.HasValue) request.AddParameter("Status", options.Status);
+            if (!String.IsNullOrEmpty(options.Status)) request.AddParameter("Status", options.Status);
             if (options.FriendlyName.HasValue()) request.AddParameter("FriendlyName", options.FriendlyName);
 
             var dateCreatedParameterName = GetParameterNameWithEquality(options.DateCreatedComparison, "DateCreated");


### PR DESCRIPTION
Updated line 203 to check if options.Status IsNullOrEmpty to reflect changes made to the ConferenceListRequest object property "Status" from int to string.  Twilio uses a string for the Status option and expects a status string of "init", "in-progress", or "completed" which cannot be passed to Twilio in the form of an Int type.
