### PR TITLE
Updated UsageRecord properties UsageUnits and CountUnits

### DIFF
--- a/src/Twilio.WinRT/Model/UsageRecord.cs
+++ b/src/Twilio.WinRT/Model/UsageRecord.cs
@@ -50,7 +50,7 @@ namespace Twilio
         /// <summary>
         /// The units in which Count is measured. For example calls for calls, messages for SMS
         /// </summary>
-        public string CountUnits { get; set; }
+        public string CountUnit { get; set; }
         
         /// <summary>
         /// The amount of usage (e.g. the number of call minutes).
@@ -61,7 +61,7 @@ namespace Twilio
         /// <summary>
         /// The units in which Usage is measured. For example minutes for calls, messages for SMS
         /// </summary>
-        public string UsageUnits { get; set; }
+        public string UsageUnit { get; set; }
         
         /// <summary>
         /// The total price of the usage, in USD


### PR DESCRIPTION
Changed property names UsageUnits to UsageUnit and CountUnits to CountUnit.  When the UsageRecord deserializes from the JSON request these properties are always null because the names are not valid.  After updating the names, these properties are now being populated.
