### PR TITLE
restsharp 105.0.0 breaking changes

### DIFF
--- a/Twilio.nuspec
+++ b/Twilio.nuspec
@@ -11,7 +11,7 @@
 		<licenseUrl>https://github.com/twilio/twilio-csharp/blob/master/LICENSE.txt</licenseUrl>
 		<tags>REST SMS voice telephony phone twilio twiml ASPNETWEBPAGES</tags>
 		<dependencies>
-			<dependency id="RestSharp" />
+			<dependency id="RestSharp" version="105.0.0" />
 		</dependencies>
 		<releaseNotes>
       * 3.6.21 - Updated RestSharp reference to 104.5.0

--- a/src/Twilio.Api/Core.cs
+++ b/src/Twilio.Api/Core.cs
@@ -72,7 +72,7 @@ namespace Twilio
             _client.AddDefaultHeader("Accept-charset", "utf-8");
 #endif
 
-            _client.BaseUrl = string.Format("{0}{1}", BaseUrl, ApiVersion);
+            _client.BaseUrl = new Uri(string.Format("{0}{1}", BaseUrl, ApiVersion));
             _client.Timeout = 30500;
 
             // if acting on a subaccount, use request.AddUrlSegment("AccountSid", "value")


### PR DESCRIPTION
they moved the baseurl from a string to a uri, cast as uri and force
105.0.0 or higher restsharp in nuspec

fixes #139 
