### PR TITLE
Removed 3 duplicated properties (1 having a type mismatch that caused an...

### DIFF
--- a/src/Twilio.Mvc/StatusCallbackRequest.cs
+++ b/src/Twilio.Mvc/StatusCallbackRequest.cs
@@ -1,14 +1,18 @@
 ﻿namespace Twilio.Mvc
-{    
+{
     /// <summary>
     /// This class can be used as the parameter on your StatusCallback action. Incoming parameters will be bound here.
     /// </summary>
-    /// <remarks>http://www.twilio.com/docs/api/twiml/twilio_request</remarks>
+    /// <remarks>http://www.twilio.com/docs/api/twiml/twilio_request#asynchronous</remarks>
     public class StatusCallbackRequest : VoiceRequest
     {
+        /// <summary>
+        /// The duration in seconds of the just-completed call.
+        /// </summary>
         public float CallDuration { get; set; }
-        public string RecordingUrl { get; set; }
-        public string RecordingSid { get; set; }
-        public float RecordingDuration { get; set; }
+
+        public string Called { get; set; }
+        public string Caller { get; set; }
+        public float Duration { get; set; }
     }
 }


### PR DESCRIPTION
... exception), added 3 undocumented properties.

WebApi's JQueryMvcFormUrlEncodedFormatter was throwing an
System.Reflection.AmbiguousMatchException because RecordingDuration was
defined in this class as a float and in the base class VoiceRequest as a
string, this caused the controller StatusCallbackRequest parameter to be
passed as null.  Removed this and RecordingUrl, RecordingSid as they
were also defined in VoiceRequest.  Added Called, Caller & Duration
properties that are not documented at
http://www.twilio.com/docs/api/twiml/twilio_request#asynchronous but are
coming through from Twilio.