### PR TITLE
Remove Update Activity available boolean

### DIFF
--- a/src/Twilio.TaskRouter.Tests/ActivityTests.cs
+++ b/src/Twilio.TaskRouter.Tests/ActivityTests.cs
@@ -321,7 +321,7 @@ namespace Twilio.TaskRouter.Tests
             var client = mockClient.Object;
             var friendlyName = Utilities.MakeRandomFriendlyName();
 
-            client.UpdateActivity(WORKSPACE_SID, ACTIVITY_SID, friendlyName, true);
+            client.UpdateActivity(WORKSPACE_SID, ACTIVITY_SID, friendlyName);
 
             mockClient.Verify(trc => trc.Execute<Activity>(It.IsAny<IRestRequest>()), Times.Once);
             Assert.IsNotNull(savedRequest);
@@ -337,9 +337,6 @@ namespace Twilio.TaskRouter.Tests
             var friendlyNameParam = savedRequest.Parameters.Find(x => x.Name == "FriendlyName");
             Assert.IsNotNull(friendlyNameParam);
             Assert.AreEqual(friendlyName, friendlyNameParam.Value);
-            var availableParam = savedRequest.Parameters.Find(x => x.Name == "Available");
-            Assert.IsNotNull(availableParam);
-            Assert.AreEqual(true, availableParam.Value);
         }
 
         [Test]
@@ -352,7 +349,7 @@ namespace Twilio.TaskRouter.Tests
             manualResetEvent = new ManualResetEvent(false);
             var friendlyName = Utilities.MakeRandomFriendlyName();
 
-            client.UpdateActivity(WORKSPACE_SID, ACTIVITY_SID, friendlyName, true, activity => {
+            client.UpdateActivity(WORKSPACE_SID, ACTIVITY_SID, friendlyName, activity => {
                 manualResetEvent.Set();
             });
             manualResetEvent.WaitOne(1);
@@ -371,9 +368,6 @@ namespace Twilio.TaskRouter.Tests
             var friendlyNameParam = savedRequest.Parameters.Find(x => x.Name == "FriendlyName");
             Assert.IsNotNull(friendlyNameParam);
             Assert.AreEqual(friendlyName, friendlyNameParam.Value);
-            var availableParam = savedRequest.Parameters.Find(x => x.Name == "Available");
-            Assert.IsNotNull(availableParam);
-            Assert.AreEqual(true, availableParam.Value);
         }
     }
 }

--- a/src/Twilio.TaskRouter.Tests/ActivityTests.cs
+++ b/src/Twilio.TaskRouter.Tests/ActivityTests.cs
@@ -327,7 +327,7 @@ namespace Twilio.TaskRouter.Tests
             Assert.IsNotNull(savedRequest);
             Assert.AreEqual("Workspaces/{WorkspaceSid}/Activities/{ActivitySid}", savedRequest.Resource);
             Assert.AreEqual(Method.POST, savedRequest.Method);
-            Assert.AreEqual(4, savedRequest.Parameters.Count);
+            Assert.AreEqual(3, savedRequest.Parameters.Count);
             var workspaceSidParam = savedRequest.Parameters.Find(x => x.Name == "WorkspaceSid");
             Assert.IsNotNull(workspaceSidParam);
             Assert.AreEqual(WORKSPACE_SID, workspaceSidParam.Value);
@@ -358,7 +358,7 @@ namespace Twilio.TaskRouter.Tests
             Assert.IsNotNull(savedRequest);
             Assert.AreEqual("Workspaces/{WorkspaceSid}/Activities/{ActivitySid}", savedRequest.Resource);
             Assert.AreEqual(Method.POST, savedRequest.Method);
-            Assert.AreEqual(4, savedRequest.Parameters.Count);
+            Assert.AreEqual(3, savedRequest.Parameters.Count);
             var workspaceSidParam = savedRequest.Parameters.Find(x => x.Name == "WorkspaceSid");
             Assert.IsNotNull(workspaceSidParam);
             Assert.AreEqual(WORKSPACE_SID, workspaceSidParam.Value);

--- a/src/Twilio.TaskRouter/Activities.Async.cs
+++ b/src/Twilio.TaskRouter/Activities.Async.cs
@@ -118,9 +118,8 @@ namespace Twilio.TaskRouter
         /// <param name="workspaceSid">Workspace sid.</param>
         /// <param name="activitySid">Activity sid.</param>
         /// <param name="friendlyName">Optional friendly name.</param>
-        /// <param name="available">Optional available.</param>
         /// <param name="callback">Method to call upon successful completion</param>
-        public virtual void UpdateActivity(string workspaceSid, string activitySid, string friendlyName, bool? available, Action<Activity> callback)
+        public virtual void UpdateActivity(string workspaceSid, string activitySid, string friendlyName, Action<Activity> callback)
         {
             Require.Argument("WorkspaceSid", workspaceSid);
             Require.Argument("ActivitySid", activitySid);
@@ -132,8 +131,6 @@ namespace Twilio.TaskRouter
 
             if (friendlyName.HasValue())
                 request.AddParameter("FriendlyName", friendlyName);
-            if (available.HasValue)
-                request.AddParameter("Available", available.Value);
 
             ExecuteAsync<Activity>(request, (response) => { callback(response); });
         }

--- a/src/Twilio.TaskRouter/Activities.cs
+++ b/src/Twilio.TaskRouter/Activities.cs
@@ -114,8 +114,7 @@ namespace Twilio.TaskRouter
         /// <param name="workspaceSid">Workspace sid.</param>
         /// <param name="activitySid">Activity sid.</param>
         /// <param name="friendlyName">Optional friendly name.</param>
-        /// <param name="available">Optional available.</param>
-        public virtual Activity UpdateActivity(string workspaceSid, string activitySid, string friendlyName, bool? available)
+        public virtual Activity UpdateActivity(string workspaceSid, string activitySid, string friendlyName)
         {
             Require.Argument("WorkspaceSid", workspaceSid);
             Require.Argument("ActivitySid", activitySid);
@@ -127,8 +126,6 @@ namespace Twilio.TaskRouter
 
             if (friendlyName.HasValue())
                 request.AddParameter("FriendlyName", friendlyName);
-            if (available.HasValue)
-                request.AddParameter("Available", available.Value);
 
             return Execute<Activity>(request);
         }


### PR DESCRIPTION
 This field on an Activity cannot be updated with the REST API, so removing this from the helper library.