### PR TITLE
Loading Reservations under a Worker by default in TaskRouter JS SDK

### DIFF
--- a/src/Twilio.TaskRouter.Tests/CapabilityTests.cs
+++ b/src/Twilio.TaskRouter.Tests/CapabilityTests.cs
@@ -137,7 +137,7 @@ namespace Twilio.TaskRouter.Tests
             Assert.IsEmpty(postFilter);
 
             var tasksFetchPolicy = policies[1] as IDictionary<string, object>;
-            Assert.AreEqual("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", reservationsFetchPolicy["url"]);
+            Assert.AreEqual("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", tasksFetchPolicy["url"]);
             Assert.AreEqual("GET", tasksFetchPolicy["method"]);
             Assert.IsTrue((bool)tasksFetchPolicy["allow"]);
             queryFilter = tasksFetchPolicy["query_filter"] as IDictionary<string, object>;
@@ -212,7 +212,7 @@ namespace Twilio.TaskRouter.Tests
             Assert.IsEmpty(postFilter);
 
             var tasksFetchPolicy = policies[1] as IDictionary<string, object>;
-            Assert.AreEqual("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", reservationsFetchPolicy["url"]);
+            Assert.AreEqual("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", tasksFetchPolicy["url"]);
             Assert.AreEqual("GET", tasksFetchPolicy["method"]);
             Assert.IsTrue((bool)tasksFetchPolicy["allow"]);
             queryFilter = tasksFetchPolicy["query_filter"] as IDictionary<string, object>;

--- a/src/Twilio.TaskRouter.Tests/CapabilityTests.cs
+++ b/src/Twilio.TaskRouter.Tests/CapabilityTests.cs
@@ -124,7 +124,7 @@ namespace Twilio.TaskRouter.Tests
             Assert.AreEqual("WK789", payload["friendly_name"]);
 
             var policies = payload["policies"] as System.Collections.IList;
-            Assert.AreEqual(5, policies.Count);
+            Assert.AreEqual(6, policies.Count);
             var url = "https://event-bridge.twilio.com/v1/wschannels/AC123/WK789";
 
             var activitesFetchPolicy = policies[0] as IDictionary<string, object>;
@@ -136,8 +136,17 @@ namespace Twilio.TaskRouter.Tests
             var postFilter = activitesFetchPolicy["post_filter"] as IDictionary<string, object>;
             Assert.IsEmpty(postFilter);
 
-            var reservationsFetchPolicy = policies[1] as IDictionary<string, object>;
+            var tasksFetchPolicy = policies[1] as IDictionary<string, object>;
             Assert.AreEqual("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", reservationsFetchPolicy["url"]);
+            Assert.AreEqual("GET", tasksFetchPolicy["method"]);
+            Assert.IsTrue((bool)tasksFetchPolicy["allow"]);
+            queryFilter = tasksFetchPolicy["query_filter"] as IDictionary<string, object>;
+            Assert.IsEmpty(queryFilter);
+            postFilter = tasksFetchPolicy["post_filter"] as IDictionary<string, object>;
+            Assert.IsEmpty(postFilter);
+
+            var reservationsFetchPolicy = policies[2] as IDictionary<string, object>;
+            Assert.AreEqual("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", reservationsFetchPolicy["url"]);
             Assert.AreEqual("GET", reservationsFetchPolicy["method"]);
             Assert.IsTrue((bool)reservationsFetchPolicy["allow"]);
             queryFilter = reservationsFetchPolicy["query_filter"] as IDictionary<string, object>;
@@ -145,7 +154,7 @@ namespace Twilio.TaskRouter.Tests
             postFilter = reservationsFetchPolicy["post_filter"] as IDictionary<string, object>;
             Assert.IsEmpty(postFilter);
 
-            var getPolicy = policies[2] as IDictionary<string, object>;
+            var getPolicy = policies[3] as IDictionary<string, object>;
             Assert.AreEqual(url, getPolicy["url"]);
             Assert.AreEqual("GET", getPolicy["method"]);
             Assert.IsTrue((bool) getPolicy["allow"]);
@@ -154,7 +163,7 @@ namespace Twilio.TaskRouter.Tests
             postFilter = getPolicy["post_filter"] as IDictionary<string, object>;
             Assert.IsEmpty(postFilter);
 
-            var postPolicy = policies[3] as IDictionary<string, object>;
+            var postPolicy = policies[4] as IDictionary<string, object>;
             Assert.AreEqual(url, postPolicy["url"]);
             Assert.AreEqual("POST", postPolicy["method"]);
             Assert.IsTrue((bool)postPolicy["allow"]);
@@ -163,7 +172,7 @@ namespace Twilio.TaskRouter.Tests
             postFilter = postPolicy["post_filter"] as IDictionary<string, object>;
             Assert.IsEmpty(postFilter);
 
-            var workerFetchPolicy = policies[4] as IDictionary<string, object>;
+            var workerFetchPolicy = policies[5] as IDictionary<string, object>;
             Assert.AreEqual("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", workerFetchPolicy["url"]);
             Assert.AreEqual("GET", workerFetchPolicy["method"]);
             Assert.IsTrue((bool)workerFetchPolicy["allow"]);
@@ -190,7 +199,7 @@ namespace Twilio.TaskRouter.Tests
             Assert.AreEqual("WK789", payload["friendly_name"]);
 
             var policies = payload["policies"] as System.Collections.IList;
-            Assert.AreEqual(5, policies.Count);
+            Assert.AreEqual(6, policies.Count);
             var url = "https://event-bridge.twilio.com/v1/wschannels/AC123/WK789";
 
             var activitesFetchPolicy = policies[0] as IDictionary<string, object>;
@@ -202,8 +211,17 @@ namespace Twilio.TaskRouter.Tests
             var postFilter = activitesFetchPolicy["post_filter"] as IDictionary<string, object>;
             Assert.IsEmpty(postFilter);
 
-            var reservationsFetchPolicy = policies[1] as IDictionary<string, object>;
+            var tasksFetchPolicy = policies[1] as IDictionary<string, object>;
             Assert.AreEqual("https://taskrouter.twilio.com/v1/Workspaces/WS456/Tasks/**", reservationsFetchPolicy["url"]);
+            Assert.AreEqual("GET", tasksFetchPolicy["method"]);
+            Assert.IsTrue((bool)tasksFetchPolicy["allow"]);
+            queryFilter = tasksFetchPolicy["query_filter"] as IDictionary<string, object>;
+            Assert.IsEmpty(queryFilter);
+            postFilter = tasksFetchPolicy["post_filter"] as IDictionary<string, object>;
+            Assert.IsEmpty(postFilter);
+
+            var reservationsFetchPolicy = policies[2] as IDictionary<string, object>;
+            Assert.AreEqual("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789/Reservations/**", reservationsFetchPolicy["url"]);
             Assert.AreEqual("GET", reservationsFetchPolicy["method"]);
             Assert.IsTrue((bool)reservationsFetchPolicy["allow"]);
             queryFilter = reservationsFetchPolicy["query_filter"] as IDictionary<string, object>;
@@ -211,7 +229,7 @@ namespace Twilio.TaskRouter.Tests
             postFilter = reservationsFetchPolicy["post_filter"] as IDictionary<string, object>;
             Assert.IsEmpty(postFilter);
 
-            var getPolicy = policies[2] as IDictionary<string, object>;
+            var getPolicy = policies[3] as IDictionary<string, object>;
             Assert.AreEqual(url, getPolicy["url"]);
             Assert.AreEqual("GET", getPolicy["method"]);
             Assert.IsTrue((bool) getPolicy["allow"]);
@@ -220,7 +238,7 @@ namespace Twilio.TaskRouter.Tests
             postFilter = getPolicy["post_filter"] as IDictionary<string, object>;
             Assert.IsEmpty(postFilter);
 
-            var postPolicy = policies[3] as IDictionary<string, object>;
+            var postPolicy = policies[4] as IDictionary<string, object>;
             Assert.AreEqual(url, postPolicy["url"]);
             Assert.AreEqual("POST", postPolicy["method"]);
             Assert.IsTrue((bool)postPolicy["allow"]);
@@ -229,7 +247,7 @@ namespace Twilio.TaskRouter.Tests
             postFilter = postPolicy["post_filter"] as IDictionary<string, object>;
             Assert.IsEmpty(postFilter);
 
-            var workerFetchPolicy = policies[4] as IDictionary<string, object>;
+            var workerFetchPolicy = policies[5] as IDictionary<string, object>;
             Assert.AreEqual("https://taskrouter.twilio.com/v1/Workspaces/WS456/Workers/WK789", workerFetchPolicy["url"]);
             Assert.AreEqual("GET", workerFetchPolicy["method"]);
             Assert.IsTrue((bool)workerFetchPolicy["allow"]);

--- a/src/Twilio.TaskRouter/Capability/TaskRouterCapability.cs
+++ b/src/Twilio.TaskRouter/Capability/TaskRouterCapability.cs
@@ -55,11 +55,13 @@ namespace Twilio.TaskRouter
             } else if (channelId.Substring (0, 2).Equals("WK")) {
                 this.resourceUrl = this.baseUrl + "/Workers/" + channelId;
                 string activityUrl = this.baseUrl + "/Activities";
-                string reservationsUrl = this.baseUrl + "/Tasks/**";
+                string tasksUrl = this.baseUrl + "/Tasks/**";
+                string workerReservationsUrl = this.resourceUrl + "/Reservations/**";
 
-                // add permissions to fetch the list of activities and list of worker reservations
+                // add permissions to fetch the list of activities, tasks, and worker reservations
                 this.Allow(activityUrl, "GET");
-                this.Allow(reservationsUrl, "GET");
+                this.Allow(tasksUrl, "GET");
+                this.Allow(workerReservationsUrl, "GET");
 
             } else if (channelId.Substring (0, 2).Equals("WQ")) {
                 this.resourceUrl = this.baseUrl + "/TaskQueues/" + channelId;
@@ -217,7 +219,8 @@ namespace Twilio.TaskRouter
 
     public class TaskRouterWorkerCapability : TaskRouterCapability
     {
-        private string reservationsUrl;
+        private string tasksUrl;
+        private string workerReservationsUrl;
         private string activityUrl;
 
         /// <summary>
@@ -231,12 +234,14 @@ namespace Twilio.TaskRouter
         public TaskRouterWorkerCapability(string accountSid, string authToken, string workspaceSid, string workerSid) :
             base(accountSid, authToken, workspaceSid, workerSid)
         {
-            this.reservationsUrl = this.baseUrl + "/Tasks/**";
+            this.tasksUrl = this.baseUrl + "/Tasks/**";
             this.activityUrl = this.baseUrl + "/Activities";
+            this.workerReservationsUrl = this.resourceUrl + "/Reservations/**";
 
-            // add permissions to fetch the list of activities and list of worker reservations
+            // add permissions to fetch the list of activities, tasks and worker reservations
             this.Allow(activityUrl, "GET");
-            this.Allow(reservationsUrl, "GET");
+            this.Allow(tasksUrl, "GET");
+            this.Allow(workerReservationsUrl, "GET");
         }
 
         override
@@ -253,8 +258,10 @@ namespace Twilio.TaskRouter
 
         public void AllowReservationUpdates()
         {
-            var policy = new Policy(this.reservationsUrl, "POST", true);
-            policies.Add(policy);
+            var taskPolicy = new Policy(this.tasksUrl, "POST", true);
+            var workerReservationsPolicy = new Policy(this.workerReservationsUrl, "POST", true);
+            policies.Add(taskPolicy);
+            policies.Add(workerReservationsPolicy);
         }
     }
 

--- a/src/Twilio.TaskRouter/Capability/TaskRouterCapability.cs
+++ b/src/Twilio.TaskRouter/Capability/TaskRouterCapability.cs
@@ -258,10 +258,8 @@ namespace Twilio.TaskRouter
 
         public void AllowReservationUpdates()
         {
-            var taskPolicy = new Policy(this.tasksUrl, "POST", true);
-            var workerReservationsPolicy = new Policy(this.workerReservationsUrl, "POST", true);
-            policies.Add(taskPolicy);
-            policies.Add(workerReservationsPolicy);
+            this.Allow(this.tasksUrl, "POST");
+            this.Allow(this.workerReservationsUrl, "POST");
         }
     }
 


### PR DESCRIPTION
- Allow fetching Reservations under a Worker by default
- Allow updating Reservations under a Worker