### PR TITLE
Adding tasks_by_priority parameter to TaskQStat response

### DIFF
--- a/src/Twilio.TaskRouter.Tests/Resources/task_queue_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/task_queue_statistics.json
@@ -2,11 +2,15 @@
    "cumulative":{
       "start_time":"2014-08-06T22:23:00Z",
       "end_time":"2014-08-06T22:38:00Z",
+      "reservations_created":0,
       "reservations_accepted":0,
       "reservations_rejected":0,
       "reservations_timed_out":0,
+      "reservations_canceled":0,
+      "reservations_rescinded":0,
       "tasks_entered":0,
       "tasks_canceled":0,
+      "tasks_deleted":0,
       "tasks_moved":0,
       "avg_task_acceptance_time":0.0
    },

--- a/src/Twilio.TaskRouter.Tests/Resources/task_queue_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/task_queue_statistics.json
@@ -22,7 +22,7 @@
          "reserved":0
       },
       "tasks_by_priority":{
-         "Priority-5":1
+         "5":1
       },
       "activity_statistics":[
          {

--- a/src/Twilio.TaskRouter.Tests/Resources/task_queue_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/task_queue_statistics.json
@@ -21,6 +21,9 @@
          "assigned":1,
          "reserved":0
       },
+      "tasks_by_priority":{
+         "Priority-5":1
+      },
       "activity_statistics":[
          {
             "sid":"WA36da5e4272ecadef27920fa475617394",

--- a/src/Twilio.TaskRouter.Tests/Resources/task_queues_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/task_queues_statistics.json
@@ -32,6 +32,7 @@
                     "assigned":0,
                     "reserved":0
                 },
+                "tasks_by_priority":{},
                 "activity_statistics":[
                     {
                         "sid":"WA79bcc984ca4fe04a31f2f91807a53ca0",

--- a/src/Twilio.TaskRouter.Tests/Resources/task_queues_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/task_queues_statistics.json
@@ -11,11 +11,15 @@
     "task_queues_statistics":[
         {
             "cumulative":{
+                "reservations_created":0,
                 "reservations_accepted":0,
                 "reservations_rejected":0,
                 "reservations_timed_out":0,
+                "reservations_canceled":0,
+                "reservations_rescinded":0,
                 "tasks_entered":0,
                 "tasks_canceled":0,
+                "tasks_deleted":0,
                 "tasks_moved":0,
                 "avg_task_acceptance_time":0.0,
                 "start_time":"2014-09-19T19:07:00Z",
@@ -62,11 +66,15 @@
         },
         {
             "cumulative":{
+                "reservations_created":0,
                 "reservations_accepted":0,
                 "reservations_rejected":0,
                 "reservations_timed_out":0,
+                "reservations_canceled":0,
+                "reservations_rescinded":0,
                 "tasks_entered":0,
                 "tasks_canceled":0,
+                "tasks_deleted":0,
                 "tasks_moved":0,
                 "avg_task_acceptance_time":0.0,
                 "start_time":"Fri, 19 Sep 2014 19:07:00 +0000",

--- a/src/Twilio.TaskRouter.Tests/Resources/workflow_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/workflow_statistics.json
@@ -18,11 +18,15 @@
    "cumulative":{
       "start_time":"2014-08-06T22:24:00Z",
       "end_time":"2014-08-06T22:39:00Z",
+      "reservations_created":0,
       "reservations_accepted":0,
       "reservations_rejected":0,
       "reservations_timed_out":0,
+      "reservations_canceled":0,
+      "reservations_rescinded":0,
       "tasks_entered":0,
       "tasks_canceled":0,
+      "tasks_deleted":0,
       "tasks_moved":0,
       "avg_task_acceptance_time":0.0,
       "tasks_timed_out_in_workflow":0

--- a/src/Twilio.TaskRouter.Tests/Resources/workflow_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/workflow_statistics.json
@@ -7,6 +7,9 @@
          "pending":0,
          "assigned":1,
          "reserved":0
+      },
+      "tasks_by_priority":{
+         "Priority-5":1
       }
    },
    "account_sid":"ACe0228445f532b79547997ce0a552cc7a",

--- a/src/Twilio.TaskRouter.Tests/Resources/workflow_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/workflow_statistics.json
@@ -9,7 +9,7 @@
          "reserved":0
       },
       "tasks_by_priority":{
-         "Priority-5":1
+         "5":1
       }
    },
    "account_sid":"ACe0228445f532b79547997ce0a552cc7a",

--- a/src/Twilio.TaskRouter.Tests/Resources/workspace_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/workspace_statistics.json
@@ -21,6 +21,9 @@
          "assigned": 1,
          "reserved": 0
       },
+      "tasks_by_priority":{
+         "Priority-5":1
+      },
       "activity_statistics": [
          {
             "sid": "WA36da5e4272ecadef27920fa475617394",

--- a/src/Twilio.TaskRouter.Tests/Resources/workspace_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/workspace_statistics.json
@@ -2,11 +2,15 @@
    "cumulative": {
       "start_time": "2014-08-06T22:22:00Z",
       "end_time": "2014-08-06T22:37:00Z",
+      "reservations_created": 0,
       "reservations_accepted": 0,
       "reservations_rejected": 0,
       "reservations_timed_out": 0,
+      "reservations_canceled": 0,
+      "reservations_rescinded": 0,
       "tasks_created": 0,
       "tasks_canceled": 0,
+      "tasks_deleted": 0,
       "tasks_moved": 0,
       "tasks_timed_out_in_workflow": 0,
       "avg_task_acceptance_time": 0.0

--- a/src/Twilio.TaskRouter.Tests/Resources/workspace_statistics.json
+++ b/src/Twilio.TaskRouter.Tests/Resources/workspace_statistics.json
@@ -22,7 +22,7 @@
          "reserved": 0
       },
       "tasks_by_priority":{
-         "Priority-5":1
+         "5":1
       },
       "activity_statistics": [
          {

--- a/src/Twilio.TaskRouter/Model/TaskQueueStatistics.cs
+++ b/src/Twilio.TaskRouter/Model/TaskQueueStatistics.cs
@@ -97,7 +97,7 @@ namespace Twilio.TaskRouter
             /// <summary>
             /// Gets or sets the tasks by priority.
             /// </summary>
-            public Dictionary<string, long> TasksByPriority { get; set; }
+            public Dictionary<string, int> TasksByPriority { get; set; }
             /// <summary>
             /// Gets or sets the activity statistics.
             /// </summary>

--- a/src/Twilio.TaskRouter/Model/TaskQueueStatistics.cs
+++ b/src/Twilio.TaskRouter/Model/TaskQueueStatistics.cs
@@ -95,6 +95,10 @@ namespace Twilio.TaskRouter
             /// </summary>
             public TasksByStatus TasksByStatus { get; set; }
             /// <summary>
+            /// Gets or sets the tasks by priority.
+            /// </summary>
+            public Dictionary<string, long> TasksByPriority { get; set; }
+            /// <summary>
             /// Gets or sets the activity statistics.
             /// </summary>
             public List<ActivityStatistics> ActivityStatistics { get; set; }

--- a/src/Twilio.TaskRouter/Model/TaskQueueStatistics.cs
+++ b/src/Twilio.TaskRouter/Model/TaskQueueStatistics.cs
@@ -43,6 +43,10 @@ namespace Twilio.TaskRouter
             /// </summary>
             public DateTimeOffset? EndTime { get; set; }
             /// <summary>
+            /// Gets or sets the reservations created.
+            /// </summary>
+            public int? ReservationsCreated { get; set; }
+            /// <summary>
             /// Gets or sets the reservations accepted.
             /// </summary>
             public int? ReservationsAccepted { get; set; }
@@ -55,6 +59,14 @@ namespace Twilio.TaskRouter
             /// </summary>
             public int? ReservationsTimedOut { get; set; }
             /// <summary>
+            /// Gets or sets the reservations canceled.
+            /// </summary>
+            public int? ReservationsCanceled { get; set; }
+            /// <summary>
+            /// Gets or sets the reservations rescinded.
+            /// </summary>
+            public int? ReservationsRescinded { get; set; }
+            /// <summary>
             /// Gets or sets the tasks entered.
             /// </summary>
             public int? TasksEntered { get; set; }
@@ -62,6 +74,10 @@ namespace Twilio.TaskRouter
             /// Gets or sets the tasks canceled.
             /// </summary>
             public int? TasksCanceled { get; set; }
+            /// <summary>
+            /// Gets or sets the tasks deleted.
+            /// </summary>
+            public int? TasksDeleted { get; set; }
             /// <summary>
             /// Gets or sets the tasks moved.
             /// </summary>

--- a/src/Twilio.TaskRouter/Model/WorkflowStatistics.cs
+++ b/src/Twilio.TaskRouter/Model/WorkflowStatistics.cs
@@ -101,7 +101,7 @@ namespace Twilio.TaskRouter
             /// <summary>
             /// Gets or sets the tasks by priority.
             /// </summary>
-            public Dictionary<string, long> TasksByPriority { get; set; }
+            public Dictionary<string, int> TasksByPriority { get; set; }
         }
 
         /// <summary>

--- a/src/Twilio.TaskRouter/Model/WorkflowStatistics.cs
+++ b/src/Twilio.TaskRouter/Model/WorkflowStatistics.cs
@@ -43,6 +43,10 @@ namespace Twilio.TaskRouter
             /// </summary>
             public DateTimeOffset? EndTime { get; set; }
             /// <summary>
+            /// Gets or sets the reservations created.
+            /// </summary>
+            public int? ReservationsCreated { get; set; }
+            /// <summary>
             /// Gets or sets the reservations accepted.
             /// </summary>
             public int? ReservationsAccepted { get; set; }
@@ -55,6 +59,14 @@ namespace Twilio.TaskRouter
             /// </summary>
             public int? ReservationsTimedOut { get; set; }
             /// <summary>
+            /// Gets or sets the reservations canceled.
+            /// </summary>
+            public int? ReservationsCanceled { get; set; }
+            /// <summary>
+            /// Gets or sets the reservations rescinded.
+            /// </summary>
+            public int? ReservationsRescinded { get; set; }
+            /// <summary>
             /// Gets or sets the tasks entered.
             /// </summary>
             public int? TasksEntered { get; set; }
@@ -62,6 +74,10 @@ namespace Twilio.TaskRouter
             /// Gets or sets the tasks canceled.
             /// </summary>
             public int? TasksCanceled { get; set; }
+            /// <summary>
+            /// Gets or sets the tasks deleted.
+            /// </summary>
+            public int? TasksDeleted { get; set; }
             /// <summary>
             /// Gets or sets the tasks moved.
             /// </summary>

--- a/src/Twilio.TaskRouter/Model/WorkflowStatistics.cs
+++ b/src/Twilio.TaskRouter/Model/WorkflowStatistics.cs
@@ -98,6 +98,10 @@ namespace Twilio.TaskRouter
             /// Gets or sets the tasks by status.
             /// </summary>
             public TasksByStatus TasksByStatus { get; set; }
+            /// <summary>
+            /// Gets or sets the tasks by priority.
+            /// </summary>
+            public Dictionary<string, long> TasksByPriority { get; set; }
         }
 
         /// <summary>

--- a/src/Twilio.TaskRouter/Model/WorkspaceStatistics.cs
+++ b/src/Twilio.TaskRouter/Model/WorkspaceStatistics.cs
@@ -58,6 +58,10 @@ namespace Twilio.TaskRouter
             /// </summary>
             public DateTimeOffset? EndTime { get; set; }
             /// <summary>
+            /// Gets or sets the reservations created.
+            /// </summary>
+            public int? ReservationsCreated { get; set; }
+            /// <summary>
             /// Gets or sets the reservations accepted.
             /// </summary>
             public int? ReservationsAccepted { get; set; }
@@ -70,6 +74,14 @@ namespace Twilio.TaskRouter
             /// </summary>
             public int? ReservationsTimedOut { get; set; }
             /// <summary>
+            /// Gets or sets the reservations canceled.
+            /// </summary>
+            public int? ReservationsCanceled { get; set; }
+            /// <summary>
+            /// Gets or sets the reservations rescinded.
+            /// </summary>
+            public int? ReservationsRescinded { get; set; }
+            /// <summary>
             /// Gets or sets the tasks created.
             /// </summary>
             public int? TasksCreated { get; set; }
@@ -77,6 +89,10 @@ namespace Twilio.TaskRouter
             /// Gets or sets the tasks canceled.
             /// </summary>
             public int? TasksCanceled { get; set; }
+            /// <summary>
+            /// Gets or sets the tasks deleted.
+            /// </summary>
+            public int? TasksDeleted { get; set; }
             /// <summary>
             /// Gets or sets the tasks moved.
             /// </summary>

--- a/src/Twilio.TaskRouter/Model/WorkspaceStatistics.cs
+++ b/src/Twilio.TaskRouter/Model/WorkspaceStatistics.cs
@@ -118,6 +118,10 @@ namespace Twilio.TaskRouter
             /// </summary>
             public TasksByStatus TasksByStatus { get; set; }
             /// <summary>
+            /// Gets or sets the tasks by priority.
+            /// </summary>
+            public Dictionary<string, long> TasksByPriority { get; set; }
+            /// <summary>
             /// Gets or sets the activity statistics.
             /// </summary>
             public List<ActivityStatistics> ActivityStatistics { get; set; }

--- a/src/Twilio.TaskRouter/Model/WorkspaceStatistics.cs
+++ b/src/Twilio.TaskRouter/Model/WorkspaceStatistics.cs
@@ -120,7 +120,7 @@ namespace Twilio.TaskRouter
             /// <summary>
             /// Gets or sets the tasks by priority.
             /// </summary>
-            public Dictionary<string, long> TasksByPriority { get; set; }
+            public Dictionary<string, int> TasksByPriority { get; set; }
             /// <summary>
             /// Gets or sets the activity statistics.
             /// </summary>


### PR DESCRIPTION
GET request to TaskQueue, Workflow and Workspace Statistics will have a field "tasks_by_priority" under RealTime Stats, similar to the "tasks_by_status" field. 

Example: 
"tasks_by_priority": {"5":1}
