### PR TITLE
Include the SmsStatusCallback parameter on requests for applications

### DIFF
--- a/src/Twilio.Api.Silverlight/Applications.Async.cs
+++ b/src/Twilio.Api.Silverlight/Applications.Async.cs
@@ -80,6 +80,7 @@ namespace Twilio
 				if (options.SmsMethod.HasValue()) request.AddParameter("SmsMethod", options.SmsMethod.ToString());
 				if (options.SmsFallbackUrl != null) request.AddParameter("SmsFallbackUrl", options.SmsFallbackUrl);
 				if (options.SmsFallbackMethod.HasValue()) request.AddParameter("SmsFallbackMethod", options.SmsFallbackMethod.ToString());
+			    if (options.SmsStatusCallback.HasValue()) request.AddParameter("SmsStatusCallback", options.SmsStatusCallback.ToString());
 			}
 
 			ExecuteAsync<Application>(request, (response) => { callback(response); });
@@ -114,7 +115,8 @@ namespace Twilio
 				if (options.SmsMethod.HasValue()) request.AddParameter("SmsMethod", options.SmsMethod.ToString());
 				if (options.SmsFallbackUrl != null) request.AddParameter("SmsFallbackUrl", options.SmsFallbackUrl);
 				if (options.SmsFallbackMethod.HasValue()) request.AddParameter("SmsFallbackMethod", options.SmsFallbackMethod.ToString());
-			}
+                if (options.SmsStatusCallback.HasValue()) request.AddParameter("SmsStatusCallback", options.SmsStatusCallback.ToString());
+            }
 
 			ExecuteAsync<Application>(request, (response) => { callback(response); });
 		}

--- a/src/Twilio.Api/Applications.cs
+++ b/src/Twilio.Api/Applications.cs
@@ -76,7 +76,8 @@ namespace Twilio
 				if (options.SmsMethod.HasValue()) request.AddParameter("SmsMethod", options.SmsMethod.ToString());
 				if (options.SmsFallbackUrl != null) request.AddParameter("SmsFallbackUrl", options.SmsFallbackUrl);
 				if (options.SmsFallbackMethod.HasValue()) request.AddParameter("SmsFallbackMethod", options.SmsFallbackMethod.ToString());
-			}
+                if (options.SmsStatusCallback.HasValue()) request.AddParameter("SmsStatusCallback", options.SmsStatusCallback.ToString());
+            }
 
 			return Execute<Application>(request);
 		}
@@ -109,7 +110,8 @@ namespace Twilio
 				if (options.SmsMethod.HasValue()) request.AddParameter("SmsMethod", options.SmsMethod.ToString());
 				if (options.SmsFallbackUrl != null) request.AddParameter("SmsFallbackUrl", options.SmsFallbackUrl);
 				if (options.SmsFallbackMethod.HasValue()) request.AddParameter("SmsFallbackMethod", options.SmsFallbackMethod.ToString());
-			}
+                if (options.SmsStatusCallback.HasValue()) request.AddParameter("SmsStatusCallback", options.SmsStatusCallback.ToString());
+            }
 
 			return Execute<Application>(request);
 		}


### PR DESCRIPTION
What it says on the tin. SmsStatusCallback was omitted when building the request for adding or updating an application. Now it's not.
