### PR TITLE
Conference instruction

### DIFF
--- a/src/Twilio.TaskRouter/Reservations.Async.cs
+++ b/src/Twilio.TaskRouter/Reservations.Async.cs
@@ -151,6 +151,12 @@ namespace Twilio.TaskRouter
         /// <param name="redirectAccept">Optional Redirect Accept.</param>
         /// <param name="redirectUrl">Optional Redirect Url.</param>
         /// <param name="callback">Method to call upon successful completion</param>
+        /// <param name="conferenceRoomName">Optional Conference Room Name.</param>
+        /// <param name="conferenceTo">Optional Conference To.</param>
+        /// <param name="conferenceFrom">Optional Conference From.</param>
+        /// <param name="conferencePostWorkActivitySid">Optional Conference Post Work Activity Sid.<param>
+        /// <param name="conferenceTimeout>Optional Conference Timeout.</param>
+        /// <param name="conferenceStatusCallbackUrl">Optional Conference Status Callback Url.</param>
         public virtual void UpdateReservation(
             string workspaceSid,
             string resource,
@@ -175,7 +181,13 @@ namespace Twilio.TaskRouter
             string callAccept = null,
             string redirectCallSid = null,
             string redirectAccept = null,
-            string redirectUrl = null
+            string redirectUrl = null,
+            string conferenceRoomName = null,
+            string conferenceTo = null,
+            string conferenceFrom = null,
+            string conferencePostWorkActivitySid = null,
+            string conferenceTimeout = null,
+            string conferenceStatusCallbackUrl = null
         )
         {
             Require.Argument("WorkspaceSid", workspaceSid);
@@ -248,6 +260,24 @@ namespace Twilio.TaskRouter
 
             if (!String.IsNullOrEmpty(redirectUrl))
                 request.AddParameter("RedirectUrl", redirectUrl);
+
+            if (!String.IsNullOrEmpty(conferenceRoomName))
+                request.AddParameter("ConferenceRoomName", conferenceRoomName);
+
+            if (!String.IsNullOrEmpty(conferenceTo))
+                request.AddParameter("ConferenceTo", conferenceTo);
+
+            if (!String.IsNullOrEmpty(conferenceFrom))
+                request.AddParameter("ConferenceFrom", conferenceFrom);
+
+            if (!String.IsNullOrEmpty(conferencePostWorkActivitySid))
+                request.AddParameter("ConferencePostWorkActivitySid", conferencePostWorkActivitySid);
+
+            if (!String.IsNullOrEmpty(conferenceTimeout))
+                request.AddParameter("ConferenceTimeout", conferenceTimeout);
+
+            if (!String.IsNullOrEmpty(conferenceStatusCallbackUrl))
+                request.AddParameter("ConferenceStatusCallbackUrl", conferenceStatusCallbackUrl);
 
             ExecuteAsync<Reservation>(request, (response) => { callback(response); });
         }

--- a/src/Twilio.TaskRouter/Reservations.cs
+++ b/src/Twilio.TaskRouter/Reservations.cs
@@ -154,6 +154,12 @@ namespace Twilio.TaskRouter
         /// <param name="redirectCallSid">Optional Redirect Call Sid.</param>
         /// <param name="redirectAccept">Optional Redirect Accept.</param>
         /// <param name="redirectUrl">Optional Redirect Url.</param>
+        /// <param name="conferenceRoomName">Optional Conference Room Name.</param>
+        /// <param name="conferenceTo">Optional Conference To.</param>
+        /// <param name="conferenceFrom">Optional Conference From.</param>
+        /// <param name="conferencePostWorkActivitySid">Optional Conference Post Work Activity Sid.<param>
+        /// <param name="conferenceTimeout>Optional Conference Timeout.</param>
+        /// <param name="conferenceStatusCallbackUrl">Optional Conference Status Callback Url.</param>
         public virtual Reservation UpdateReservation(
             string workspaceSid,
             string resource,
@@ -177,7 +183,13 @@ namespace Twilio.TaskRouter
             string callAccept = null,
             string redirectCallSid = null,
             string redirectAccept = null,
-            string redirectUrl = null
+            string redirectUrl = null,
+            string conferenceRoomName = null,
+            string conferenceTo = null,
+            string conferenceFrom = null,
+            string conferencePostWorkActivitySid = null,
+            string conferenceTimeout = null,
+            string conferenceStatusCallbackUrl = null
         )
         {
             Require.Argument("WorkspaceSid", workspaceSid);
@@ -248,6 +260,24 @@ namespace Twilio.TaskRouter
 
             if (!String.IsNullOrEmpty(redirectUrl))
                 request.AddParameter("RedirectUrl", redirectUrl);
+
+            if (!String.IsNullOrEmpty(conferenceRoomName))
+                request.AddParameter("ConferenceRoomName", conferenceRoomName);
+
+            if (!String.IsNullOrEmpty(conferenceTo))
+                request.AddParameter("ConferenceTo", conferenceTo);
+
+            if (!String.IsNullOrEmpty(conferenceFrom))
+                request.AddParameter("ConferenceFrom", conferenceFrom);
+
+            if (!String.IsNullOrEmpty(conferencePostWorkActivitySid))
+                request.AddParameter("ConferencePostWorkActivitySid", conferencePostWorkActivitySid);
+
+            if (!String.IsNullOrEmpty(conferenceTimeout))
+                request.AddParameter("ConferenceTimeout", conferenceTimeout);
+
+            if (!String.IsNullOrEmpty(conferenceStatusCallbackUrl))
+                request.AddParameter("ConferenceStatusCallbackUrl", conferenceStatusCallbackUrl);
 
             return Execute<Reservation>(request);
         }

--- a/src/Twilio.Twiml.Tests/DialTests.cs
+++ b/src/Twilio.Twiml.Tests/DialTests.cs
@@ -201,5 +201,30 @@ namespace Twilio.TwiML.Tests
 
             Assert.IsTrue(IsValidTwiML(response.ToXDocument()));
         }       
+
+        [Test]
+        public void Can_Generate_Dial_And_Conf_And_Task()
+        {
+            var task = new Task("{'task':'attributes'}", new {priority = "10", timeout = "30"});
+
+            var response = new TwilioResponse();
+            response.DialConference("room1", task);
+
+            Assert.IsTrue(IsValidTwiML(response.ToXDocument()));
+        }
+
+        [Test]
+        public void Can_Generate_Dial_And_Conf_And_Task_Params()
+        {
+            var response = new TwilioResponse();
+            response.DialConference("room1",
+                new { muted = true, beep = false, waitUrl = "wait.xml", waitMethod = "GET" },
+                new { action = "dial.xml", method = "GET", timeout = "30", hangupOnStar = "true", timeLimit = "1000", callerId = "555-111-2222" },
+                "{'task':'attributes'}",
+                new { priority = "10", timeout = "15"}
+            );
+
+            Assert.IsTrue(IsValidTwiML(response.ToXDocument()));
+        }
 	}
 }

--- a/src/Twilio.Twiml.Tests/TwiML.xsd
+++ b/src/Twilio.Twiml.Tests/TwiML.xsd
@@ -153,27 +153,26 @@
 	</xs:complexType>
 
   <!-- <Conference> -->
-  <xs:complexType name="ConferenceType">
-    <xs:simpleContent>
-      <xs:extension base="xs:string">
-        <xs:attribute name="beep" type="xs:boolean"></xs:attribute>
-        <xs:attribute name="endConferenceOnExit" type="xs:boolean"></xs:attribute>
-        <xs:attribute name="maxParticipants">
-          <xs:simpleType>
-            <xs:restriction base="xs:int">
-              <xs:minInclusive value="1" />
-              <xs:maxInclusive value="40" />
-            </xs:restriction>
-          </xs:simpleType>
-        </xs:attribute>
-        <!--<xs:attribute name="method" type="MethodType"></xs:attribute>-->
-        <xs:attribute name="muted" type="xs:boolean"></xs:attribute>
-        <xs:attribute name="startConferenceOnEnter" type="xs:boolean"></xs:attribute>
-        <!--<xs:attribute name="url" type="xs:string"></xs:attribute>-->
-        <xs:attribute name="waitMethod" type="xs:string"></xs:attribute>
-        <xs:attribute name="waitUrl" type="xs:string"></xs:attribute>
-      </xs:extension>
-    </xs:simpleContent>
+  <xs:complexType name="ConferenceType" mixed="true">
+    <xs:choice>
+      <xs:element name="Task" type="TaskType" minOccurs="0" maxOccurs="unbounded"></xs:element>
+    </xs:choice>
+    <xs:attribute name="beep" type="xs:boolean"></xs:attribute>
+    <xs:attribute name="endConferenceOnExit" type="xs:boolean"></xs:attribute>
+    <xs:attribute name="maxParticipants">
+      <xs:simpleType>
+        <xs:restriction base="xs:int">
+          <xs:minInclusive value="1" />
+          <xs:maxInclusive value="40" />
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <!--<xs:attribute name="method" type="MethodType"></xs:attribute>-->
+    <xs:attribute name="muted" type="xs:boolean"></xs:attribute>
+    <xs:attribute name="startConferenceOnEnter" type="xs:boolean"></xs:attribute>
+    <!--<xs:attribute name="url" type="xs:string"></xs:attribute>-->
+    <xs:attribute name="waitMethod" type="xs:string"></xs:attribute>
+    <xs:attribute name="waitUrl" type="xs:string"></xs:attribute>
   </xs:complexType>
 
   <!-- <Sip> -->
@@ -331,6 +330,7 @@
 
   <!-- <Task> -->
   <xs:complexType name="TaskType" mixed="true">
+    <xs:attribute name="workflowSid" type="xs:string"></xs:attribute>
     <xs:attribute name="priority" type="xs:string"></xs:attribute>
     <xs:attribute name="timeout" type="xs:string"></xs:attribute>
   </xs:complexType>

--- a/src/Twilio.Twiml/TwilioResponse.cs
+++ b/src/Twilio.Twiml/TwilioResponse.cs
@@ -187,6 +187,40 @@ namespace Twilio.TwiML
 		}
 
         /// <summary>
+        /// Dials the conference.
+        /// </summary>
+        /// <returns>The conference.</returns>
+        /// <param name="room">The conference room name.</param>
+        /// <param name="task">Task.</param>
+        public TwilioResponse DialConference(string room, Task task)
+        {
+            BeginDial();
+            var conference = new Conference(room);
+            Current.Push(conference);
+            Add(task);
+            Add(Current.Pop());
+            return EndDial();
+        }
+
+        /// <summary>
+        /// Dials the conference.
+        /// </summary>
+        /// <returns>The conference.</returns>
+        /// <param name="room">Room.</param>
+        /// <param name="conferenceAttributes">Conference attributes.</param>
+        /// <param name="dialAttributes">Dial attributes.</param>
+        /// <param name="taskAttributes">Task attributes.</param>
+        /// <param name="taskProperties">Task properties.</param>
+        public TwilioResponse DialConference(string room, object conferenceAttributes, object dialAttributes, string taskAttributes, object taskProperties)
+        {
+            BeginDial(dialAttributes);
+            Current.Push(new Conference(room, conferenceAttributes));
+            if (!string.IsNullOrEmpty(taskAttributes)) { Add(new Task(taskAttributes, taskProperties)); }
+            Add(Current.Pop());
+            return EndDial();
+        }
+
+        /// <summary>
         /// Adds the current caller to a Queue
         /// </summary>
         /// <param name="queue">The Queue to add the user to</param>

--- a/src/Twilio.Twiml/Verbs/Conference.cs
+++ b/src/Twilio.Twiml/Verbs/Conference.cs
@@ -35,7 +35,6 @@ namespace Twilio.TwiML
 			Element = new XElement("Conference");
 
             AllowedChildren.Add("Task");
-            AllowedChildren.Add("TaskAttributes");
 
 			AllowedAttributes.Add("muted");
 			AllowedAttributes.Add("beep");

--- a/src/Twilio.Twiml/Verbs/Conference.cs
+++ b/src/Twilio.Twiml/Verbs/Conference.cs
@@ -34,6 +34,9 @@ namespace Twilio.TwiML
 		{
 			Element = new XElement("Conference");
 
+            AllowedChildren.Add("Task");
+            AllowedChildren.Add("TaskAttributes");
+
 			AllowedAttributes.Add("muted");
 			AllowedAttributes.Add("beep");
 			AllowedAttributes.Add("waitUrl");

--- a/src/Twilio.Twiml/Verbs/Task.cs
+++ b/src/Twilio.Twiml/Verbs/Task.cs
@@ -16,6 +16,7 @@ namespace Twilio.TwiML
         {
             Element = new XElement("Task", taskattributes);
 
+            AllowedAttributes.Add("workflowSid");
             AllowedAttributes.Add("priority");
             AllowedAttributes.Add("timeout");
         }


### PR DESCRIPTION
Adding support for a Task noun nested beneath a Conference noun.
Included parameters for issuing a "conference" instruction on a Reservation update.
