### PR TITLE
Update InboundSmsPrice.cs

### DIFF
--- a/Twilio/Types/InboundSmsPrice.cs
+++ b/Twilio/Types/InboundSmsPrice.cs
@@ -16,12 +16,12 @@ namespace Twilio.Types
 	    }
 
 	    [JsonProperty("base_price")]
-	    public double? BasePrice { get; }
+	    public double? BasePrice { get; private set; }
 	    [JsonProperty("current_price")]
-	    public double? CurrentPrice { get; }
-	    [JsonProperty("type")]
+	    public double? CurrentPrice { get; private set; }
+	    [JsonProperty("number_type")]
 	    [JsonConverter(typeof(StringEnumConverter))]
-	    public TypeEnum Type { get; }
+	    public TypeEnum Type { get; private set; }
 
 	    public InboundSmsPrice() {}
 
@@ -30,7 +30,7 @@ namespace Twilio.Types
 	        double? basePrice,
 	        [JsonProperty("current_priece")]
 	        double? currentPrice,
-	        [JsonProperty("type")]
+	        [JsonProperty("number_type")]
 	        TypeEnum type
 	    )
 	    {


### PR DESCRIPTION
Changed [JsonProperty("type")] to [JsonProperty("number_type")] as API "https://pricing.twilio.com/v1/Messaging/Countries/US" returns it as "number_type". Added "private set" accessor to properties in order them could be initialized, otherwise they were always null.