### PR TITLE
Fix async/await for MVC/WPF apps

### DIFF
--- a/src/Twilio/Http/SystemNetHttpClient.cs
+++ b/src/Twilio/Http/SystemNetHttpClient.cs
@@ -57,15 +57,15 @@ namespace Twilio.Http
             HttpResponseMessage response = null;
             try
             {
-                response = await _httpClient.SendAsync(httpRequest); 
-                var reader = new StreamReader(await response.Content.ReadAsStreamAsync());
-                return new Response(response.StatusCode, await reader.ReadToEndAsync());
+                response = await _httpClient.SendAsync(httpRequest).ConfigureAwait(false); 
+                var reader = new StreamReader(await response.Content.ReadAsStreamAsync().ConfigureAwait(false));
+                return new Response(response.StatusCode, await reader.ReadToEndAsync().ConfigureAwait(false));
             }
             catch (AggregateException ae)
             {
                 if (ae.InnerExceptions.OfType<HttpRequestException>().Any() && response != null)
                 {
-                    throw await HandleErrorResponse(response);
+                    throw await HandleErrorResponse(response).ConfigureAwait(false);
                 }
             }
             return null;
@@ -79,7 +79,7 @@ namespace Twilio.Http
                 return new TwilioException("Internal Server error: " + errorResponse.StatusCode);
             }
 
-            var responseStream = await errorResponse.Content.ReadAsStreamAsync();
+            var responseStream = await errorResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
             var errorReader = new StreamReader(responseStream);
             var errorContent = errorReader.ReadToEnd();
 


### PR DESCRIPTION
So when calling the non-asynchronous methods in the library, we do a Task.Wait() on the asynchronous versions. Those will deadlock in an MVC or WPF app because it will try to resume on the same thread to maintain the same context, but we've already blocked the thread with Task.Wait().

Adding `.ConfigureAwait(false)` within the library code tells our library we don't need it to return with the same context and thus avoids the deadlock.

See here for reference: https://msdn.microsoft.com/en-us/magazine/jj991977.aspx