### PR TITLE
Allow empty string for gather finishOnKey attribute

### DIFF
--- a/src/Twilio/TwiML/Gather.cs
+++ b/src/Twilio/TwiML/Gather.cs
@@ -43,7 +43,7 @@ namespace Twilio.TwiML
             {
                 Element.Add(new XAttribute("method", method));
             }
-            if (!string.IsNullOrEmpty(finishOnKey))
+            if (finishOnKey != null)
             {
                 Element.Add(new XAttribute("finishOnKey", finishOnKey));
             }

--- a/src/Twilio/TwiML/VoiceResponse.cs
+++ b/src/Twilio/TwiML/VoiceResponse.cs
@@ -196,7 +196,7 @@ namespace Twilio.TwiML
             {
                 gather.Add(new XAttribute("method", method));
             }
-            if (!string.IsNullOrEmpty(finishOnKey))
+            if (finishOnKey != null)
             {
                 gather.Add(new XAttribute("finishOnKey", finishOnKey));
             }

--- a/test/Twilio.Test/TwiML/VoiceResponseTest.cs
+++ b/test/Twilio.Test/TwiML/VoiceResponseTest.cs
@@ -84,6 +84,21 @@ namespace Twilio.Tests.TwiML
         }
 
         [Test]
+        public void TestGatherEmptyFinishOnKey()
+        {
+            var vr = new VoiceResponse();
+            vr.Gather(timeout: 5, finishOnKey: string.Empty);
+
+            Assert.AreEqual(
+                vr.ToString(),
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
+                "<Response>" + Environment.NewLine +
+                "  <Gather timeout=\"5\" finishOnKey=\"\" />" + Environment.NewLine +
+                "</Response>"
+            );
+        }
+
+        [Test]
         public void TestNestedGather()
         {
             var gather = new Gather();
@@ -97,6 +112,26 @@ namespace Twilio.Tests.TwiML
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
                 "<Response>" + Environment.NewLine +
                 "  <Gather>" + Environment.NewLine +
+                "    <Say>Hello world</Say>" + Environment.NewLine +
+                "  </Gather>" + Environment.NewLine +
+                "</Response>"
+            );
+        }
+
+        [Test]
+        public void TestNestedGatherFinishOnKey()
+        {
+            var gather = new Gather(finishOnKey: string.Empty);
+            gather.Say("Hello world");
+
+            var vr = new VoiceResponse();
+            vr.Gather(gather);
+
+            Assert.AreEqual(
+                vr.ToString(),
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
+                "<Response>" + Environment.NewLine +
+                "  <Gather finishOnKey=\"\">" + Environment.NewLine +
                 "    <Say>Hello world</Say>" + Environment.NewLine +
                 "  </Gather>" + Environment.NewLine +
                 "</Response>"


### PR DESCRIPTION
It is not currently possible to set the `finishOnKey` attribute on `Gather` to the empty string. This PR enables this scenario.