### PR TITLE
Remove "$" String Interpolation to Support Compilation in .NET <4.6

### DIFF
--- a/src/Twilio/JWT/AccessToken/Token.cs
+++ b/src/Twilio/JWT/AccessToken/Token.cs
@@ -35,7 +35,7 @@ namespace Twilio.Jwt.AccessToken
         ) : base(secret, signingKeySid, expiration.HasValue ? expiration.Value : DateTime.UtcNow.AddSeconds(3600))
         {
             var now = BaseJwt.ConvertToUnixTimestamp(DateTime.UtcNow);
-            this._id = $"{signingKeySid}-{now}";
+            this._id = signingKeySid + "-" + now;
             this._accountSid = accountSid;
             this._identity = identity;
             this._nbf = nbf;

--- a/src/Twilio/JWT/Client/EventStreamScope.cs
+++ b/src/Twilio/JWT/Client/EventStreamScope.cs
@@ -43,7 +43,7 @@ namespace Twilio.Jwt.Client
                 }
 
                 var queryString = String.Join("&", queryArgs.ToArray());
-                return $"{Scope}?{queryString}";
+                return Scope + "?" + queryString;
             }
         }
 

--- a/src/Twilio/JWT/Client/IncomingClientScope.cs
+++ b/src/Twilio/JWT/Client/IncomingClientScope.cs
@@ -27,8 +27,8 @@ namespace Twilio.Jwt.Client
         {
             get
             {
-                var query = $"clientName={_clientName}";
-                return $"{Scope}?{query}";
+                var query = "clientName=" + _clientName;
+                return Scope + "?" + query;
             }
         }
     }

--- a/src/Twilio/JWT/Client/OutgoingClientScope.cs
+++ b/src/Twilio/JWT/Client/OutgoingClientScope.cs
@@ -58,7 +58,7 @@ namespace Twilio.Jwt.Client
                 }
 
                 var queryString = String.Join("&", queryArgs.ToArray());
-                return $"{Scope}?{queryString}";
+                return Scope + "?" + queryString;
             }
         }
 

--- a/src/Twilio/JWT/Taskrouter/PolicyUtils.cs
+++ b/src/Twilio/JWT/Taskrouter/PolicyUtils.cs
@@ -21,7 +21,7 @@ namespace Twilio.Jwt.Taskrouter
         /// <returns>Default event bridge policies</returns>
         public static List<Policy> DefaultEventBridgePolicies(string accountSid, string channelId)
         {
-            var url = $"{TaskRouterEventUrl}/{accountSid}/{channelId}";
+            var url = TaskRouterEventUrl + "/" + accountSid + "/" + channelId;
             return new List<Policy>
             {
                 { new Policy(url, HttpMethod.Get) },


### PR DESCRIPTION
Refactored string concatenation within the jwt namespace to remove usage references to the C# 6.0 string interpolation feature.