### PR TITLE
Add incoming.allow to AccessToken VoiceGrant

### DIFF
--- a/src/Twilio/JWT/AccessToken/VoiceGrant.cs
+++ b/src/Twilio/JWT/AccessToken/VoiceGrant.cs
@@ -8,6 +8,11 @@ namespace Twilio.Jwt.AccessToken
     public class VoiceGrant : IGrant
     {
         /// <summary>
+        /// Whether incoming connections are allowed (JS Client)
+        /// </summary>
+        public bool IncomingAllow { get; set; }
+
+        /// <summary>
         /// Outgoing application SID
         /// </summary>
         public string OutgoingApplicationSid { get; set; }
@@ -50,6 +55,12 @@ namespace Twilio.Jwt.AccessToken
             get
             {
                 var payload = new Dictionary<string, object>();
+                if (IncomingAllow == true)
+                {
+                    var incoming = new Dictionary<string, object> { { "allow", true } };
+                    payload.Add("incoming", incoming);
+                }
+
                 if (OutgoingApplicationSid != null)
                 {
                     var outgoing = new Dictionary<string, object> { { "application_sid", OutgoingApplicationSid } };

--- a/test/Twilio.Test/Jwt/AccessToken/AccessTokenTest.cs
+++ b/test/Twilio.Test/Jwt/AccessToken/AccessTokenTest.cs
@@ -133,6 +133,7 @@ namespace Twilio.Tests.Jwt.AccessToken
                 {
                     new VoiceGrant
                     {
+                        IncomingAllow = true,
                         OutgoingApplicationSid = "AP123",
                         OutgoingApplicationParams = new Dictionary<string, string> { { "foo", "bar" } }
                     }
@@ -154,6 +155,9 @@ namespace Twilio.Tests.Jwt.AccessToken
             Assert.AreEqual(1, decodedGrants.Count);
 
             var decodedPvg = decodedGrants["voice"];
+            var incoming = ToDict(decodedPvg.ToString())["incoming"];
+            Assert.AreEqual(true, ToDict(incoming)["allow"]);
+
             var outgoing = ToDict(decodedPvg.ToString())["outgoing"];
             Assert.AreEqual("AP123", ToDict(outgoing)["application_sid"]);
 


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/CLIENT-4492

To support JS Clients per this spec:
https://paper.dropbox.com/doc/Proposal-FPA-Token-Format-for-Programmable-Voice-SDKs-xhdFHD6N3aPW9GRp4dXNX