### PR TITLE
Allow adding TwiML children with generic tag names

### DIFF
--- a/src/Twilio/TwiML/TwiML.cs
+++ b/src/Twilio/TwiML/TwiML.cs
@@ -80,7 +80,7 @@ namespace Twilio.TwiML
         }
         
         /// <summary>
-        /// Add generic node child to TwiML object
+        /// Add a generic child TwiML object
         /// </summary>
         /// <param name="tagName"> TwiML tag name </param>
         public TwiML AddChild(string tagName)

--- a/src/Twilio/TwiML/TwiML.cs
+++ b/src/Twilio/TwiML/TwiML.cs
@@ -78,6 +78,15 @@ namespace Twilio.TwiML
             this.Children.Add(childElem);
             return childElem;
         }
+        
+        /// <summary>
+        /// Add generic node child to TwiML object
+        /// </summary>
+        /// <param name="tagName"> TwiML tag name </param>
+        public TwiML AddChild(string tagName)
+        {
+            return this.Nest(new GenericNode(tagName));
+        }
 
         /// <summary>
         /// Add freeform key-value attributes to the generated xml
@@ -131,6 +140,16 @@ namespace Twilio.TwiML
             var writer = new Utf8StringWriter();
             document.Save(writer, formattingOptions);
             return writer.GetStringBuilder().ToString();
+        }
+    }
+
+    /// <summary>
+    /// Class for GenericNode object
+    /// </summary>
+    public class GenericNode : TwiML
+    {
+        public GenericNode(string tagName) : base(tagName)
+        {
         }
     }
 

--- a/src/Twilio/TwiML/TwiML.cs
+++ b/src/Twilio/TwiML/TwiML.cs
@@ -11,7 +11,7 @@ namespace Twilio.TwiML
     /// <summary>
     /// Base class for all TwiML Objects.
     /// </summary>
-    public abstract class TwiML 
+    public class TwiML 
     {
         /// <summary>
         /// Tag name
@@ -85,7 +85,7 @@ namespace Twilio.TwiML
         /// <param name="tagName"> TwiML tag name </param>
         public TwiML AddChild(string tagName)
         {
-            return this.Nest(new GenericNode(tagName));
+            return this.Nest(new TwiML(tagName));
         }
 
         /// <summary>
@@ -140,16 +140,6 @@ namespace Twilio.TwiML
             var writer = new Utf8StringWriter();
             document.Save(writer, formattingOptions);
             return writer.GetStringBuilder().ToString();
-        }
-    }
-
-    /// <summary>
-    /// Class for GenericNode object
-    /// </summary>
-    public class GenericNode : TwiML
-    {
-        public GenericNode(string tagName) : base(tagName)
-        {
         }
     }
 

--- a/test/Twilio.Test/TwiML/FaxResponseTest.cs
+++ b/test/Twilio.Test/TwiML/FaxResponseTest.cs
@@ -70,6 +70,39 @@ namespace Twilio.Tests.TwiML
                 elem.ToString()
             );
         }
+        
+        [Test]
+        public void TestAllowGenericChildNodes()
+        {
+            var elem = new FaxResponse();
+            elem.AddChild("generic-node").AddText("Generic Node").SetOption("tag", true);
+            
+            Assert.AreEqual(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
+                "<Response>" + Environment.NewLine +
+                "  <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "</Response>",
+                elem.ToString()
+            );
+        }
+        
+        [Test]
+        public void TestAllowGenericChildrenOfChildNodes()
+        {
+            var elem = new FaxResponse();
+            var child = new Receive();
+            elem.Nest(child).AddChild("generic-node").SetOption("tag", true).AddText("Generic Node");
+            
+            Assert.AreEqual(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
+                "<Response>" + Environment.NewLine +
+                "  <Receive>" + Environment.NewLine +
+                "    <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "  </Receive>" + Environment.NewLine +
+                "</Response>",
+                elem.ToString()
+            );
+        }
     }
 
 }

--- a/test/Twilio.Test/TwiML/FaxResponseTest.cs
+++ b/test/Twilio.Test/TwiML/FaxResponseTest.cs
@@ -70,34 +70,34 @@ namespace Twilio.Tests.TwiML
                 elem.ToString()
             );
         }
-        
+
         [Test]
         public void TestAllowGenericChildNodes()
         {
             var elem = new FaxResponse();
-            elem.AddChild("generic-node").AddText("Generic Node").SetOption("tag", true);
-            
+            elem.AddChild("generic-tag").AddText("Content").SetOption("tag", true);
+
             Assert.AreEqual(
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
                 "<Response>" + Environment.NewLine +
-                "  <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "  <generic-tag tag=\"True\">Content</generic-tag>" + Environment.NewLine +
                 "</Response>",
                 elem.ToString()
             );
         }
-        
+
         [Test]
         public void TestAllowGenericChildrenOfChildNodes()
         {
             var elem = new FaxResponse();
             var child = new Receive();
-            elem.Nest(child).AddChild("generic-node").SetOption("tag", true).AddText("Generic Node");
-            
+            elem.Nest(child).AddChild("generic-tag").SetOption("tag", true).AddText("Content");
+
             Assert.AreEqual(
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
                 "<Response>" + Environment.NewLine +
                 "  <Receive>" + Environment.NewLine +
-                "    <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "    <generic-tag tag=\"True\">Content</generic-tag>" + Environment.NewLine +
                 "  </Receive>" + Environment.NewLine +
                 "</Response>",
                 elem.ToString()

--- a/test/Twilio.Test/TwiML/MessagingResponseTest.cs
+++ b/test/Twilio.Test/TwiML/MessagingResponseTest.cs
@@ -98,6 +98,40 @@ namespace Twilio.Tests.TwiML
                 elem.ToString()
             );
         }
+
+        [Test]
+        public void TestAllowGenericChildNodes()
+        {
+            var elem = new MessagingResponse();
+            elem.AddChild("generic-node").AddText("Generic Node").SetOption("tag", true);
+            
+            Assert.AreEqual(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
+                "<Response>" + Environment.NewLine +
+                "  <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "</Response>",
+                elem.ToString()
+            );
+        }
+        
+        [Test]
+        public void TestAllowGenericChildrenOfChildNodes()
+        {
+            var elem = new MessagingResponse();
+            var child = new Message();
+            elem.Nest(child).AddChild("generic-node").SetOption("tag", true).AddText("Generic Node");
+            
+            Assert.AreEqual(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
+                "<Response>" + Environment.NewLine +
+                "  <Message>" + Environment.NewLine +
+                "    <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "  </Message>" + Environment.NewLine +
+                "</Response>",
+                elem.ToString()
+            );
+        }
+        
     }
 
 }

--- a/test/Twilio.Test/TwiML/MessagingResponseTest.cs
+++ b/test/Twilio.Test/TwiML/MessagingResponseTest.cs
@@ -103,35 +103,34 @@ namespace Twilio.Tests.TwiML
         public void TestAllowGenericChildNodes()
         {
             var elem = new MessagingResponse();
-            elem.AddChild("generic-node").AddText("Generic Node").SetOption("tag", true);
-            
+            elem.AddChild("generic-tag").AddText("Content").SetOption("tag", true);
+
             Assert.AreEqual(
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
                 "<Response>" + Environment.NewLine +
-                "  <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "  <generic-tag tag=\"True\">Content</generic-tag>" + Environment.NewLine +
                 "</Response>",
                 elem.ToString()
             );
         }
-        
+
         [Test]
         public void TestAllowGenericChildrenOfChildNodes()
         {
             var elem = new MessagingResponse();
             var child = new Message();
-            elem.Nest(child).AddChild("generic-node").SetOption("tag", true).AddText("Generic Node");
-            
+            elem.Nest(child).AddChild("generic-tag").SetOption("tag", true).AddText("Content");
+
             Assert.AreEqual(
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
                 "<Response>" + Environment.NewLine +
                 "  <Message>" + Environment.NewLine +
-                "    <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "    <generic-tag tag=\"True\">Content</generic-tag>" + Environment.NewLine +
                 "  </Message>" + Environment.NewLine +
                 "</Response>",
                 elem.ToString()
             );
         }
-        
     }
 
 }

--- a/test/Twilio.Test/TwiML/VoiceResponseTest.cs
+++ b/test/Twilio.Test/TwiML/VoiceResponseTest.cs
@@ -189,34 +189,34 @@ namespace Twilio.Tests.TwiML
                 elem.ToString()
             );
         }
-        
+
         [Test]
         public void TestAllowGenericChildNodes()
         {
             var elem = new VoiceResponse();
-            elem.AddChild("generic-node").AddText("Generic Node").SetOption("tag", true);
-            
+            elem.AddChild("generic-tag").AddText("Content").SetOption("tag", true);
+
             Assert.AreEqual(
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
                 "<Response>" + Environment.NewLine +
-                "  <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "  <generic-tag tag=\"True\">Content</generic-tag>" + Environment.NewLine +
                 "</Response>",
                 elem.ToString()
             );
         }
-        
+
         [Test]
         public void TestAllowGenericChildrenOfChildNodes()
         {
             var elem = new VoiceResponse();
             var child = new Dial();
-            elem.Nest(child).AddChild("generic-node").SetOption("tag", true).AddText("Generic Node");
-            
+            elem.Nest(child).AddChild("generic-tag").SetOption("tag", true).AddText("Content");
+
             Assert.AreEqual(
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
                 "<Response>" + Environment.NewLine +
                 "  <Dial>" + Environment.NewLine +
-                "    <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "    <generic-tag tag=\"True\">Content</generic-tag>" + Environment.NewLine +
                 "  </Dial>" + Environment.NewLine +
                 "</Response>",
                 elem.ToString()

--- a/test/Twilio.Test/TwiML/VoiceResponseTest.cs
+++ b/test/Twilio.Test/TwiML/VoiceResponseTest.cs
@@ -189,6 +189,39 @@ namespace Twilio.Tests.TwiML
                 elem.ToString()
             );
         }
+        
+        [Test]
+        public void TestAllowGenericChildNodes()
+        {
+            var elem = new VoiceResponse();
+            elem.AddChild("generic-node").AddText("Generic Node").SetOption("tag", true);
+            
+            Assert.AreEqual(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
+                "<Response>" + Environment.NewLine +
+                "  <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "</Response>",
+                elem.ToString()
+            );
+        }
+        
+        [Test]
+        public void TestAllowGenericChildrenOfChildNodes()
+        {
+            var elem = new VoiceResponse();
+            var child = new Dial();
+            elem.Nest(child).AddChild("generic-node").SetOption("tag", true).AddText("Generic Node");
+            
+            Assert.AreEqual(
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
+                "<Response>" + Environment.NewLine +
+                "  <Dial>" + Environment.NewLine +
+                "    <generic-node tag=\"True\">Generic Node</generic-node>" + Environment.NewLine +
+                "  </Dial>" + Environment.NewLine +
+                "</Response>",
+                elem.ToString()
+            );
+        }
     }
 
 }


### PR DESCRIPTION
- Allow generic name for TwiML nodes
- Add tests for `MessagingResponse`, `VoiceResponse` and `FaxResponse`

Note: tests are auto-generated; will make a separate PR for the code generation.