### PR TITLE
Add Dockerfile and related changes to build the Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,9 @@ install:
 
 script:
   - dotnet run --framework netcoreapp1.1 --project test/Twilio.Test/Twilio.Test.csproj
+
+deploy:
+  script:
+    - make docker-build
+    - make docker-push
+  on: tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: required
 mono: none
 dotnet: 1.1.5
 
+services:
+  - docker
+
 install:
   - dotnet restore
   - dotnet build --framework netstandard1.4 src/Twilio/Twilio.csproj
@@ -14,7 +17,8 @@ script:
   - dotnet run --framework netcoreapp1.1 --project test/Twilio.Test/Twilio.Test.csproj
 
 deploy:
-  script:
-    - make docker-build
-    - make docker-push
-  on: tags
+  provider: script
+  script: make docker-build && make docker-push
+  skip_cleanup: true
+  on:
+    tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:16.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libc6 \
+        libcurl3 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libicu55 \
+        liblttng-ust0 \
+        libssl1.0.2 \
+        libstdc++6 \
+        libunwind8 \
+        libuuid1 \
+        zlib1g \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV DOTNET_SDK_VERSION 2.1.4
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz
+ENV DOTNET_SDK_DOWNLOAD_SHA 05FE90457A8B77AD5A5EB2F22348F53E962012A55077AC4AD144B279F6CAD69740E57F165820BFD6104E88B30E93684BDE3E858F781541D4F110F28CD52CE2B7
+
+RUN curl -SL $DOTNET_SDK_DOWNLOAD_URL --output dotnet.tar.gz \
+    && echo "$DOTNET_SDK_DOWNLOAD_SHA dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -zxf dotnet.tar.gz -C /usr/share/dotnet \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && rm dotnet.tar.gz
+
+RUN mkdir /twilio
+WORKDIR /twilio
+
+COPY src ./src
+COPY test ./test
+COPY Twilio.sln .
+
+RUN dotnet restore

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ API_DEFINITIONS_SHA=$(shell git log --oneline | grep Regenerated | head -n1 | cu
 docker-build:
 	docker build -t twilio/twilio-csharp .
 	docker tag twilio/twilio-csharp twilio/twilio-csharp:${TRAVIS_TAG}
-	docker tag twilio/twilio-csharp twilio/twilio-csharp:${API_DEFINITIONS_SHA}
+	docker tag twilio/twilio-csharp twilio/twilio-csharp:apidefs-${API_DEFINITIONS_SHA}
 
 docker-push:
 	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
 	docker push twilio/twilio-csharp:${TRAVIS_TAG}
-	docker push twilio/twilio-csharp:${API_DEFINITIONS_TAG}
+	docker push twilio/twilio-csharp:apidefs-${API_DEFINITIONS_TAG}

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ docker-build:
 	docker tag twilio/twilio-csharp twilio/twilio-csharp:apidefs-${API_DEFINITIONS_SHA}
 
 docker-push:
-	echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
+	echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
 	docker push twilio/twilio-csharp:${TRAVIS_TAG}
 	docker push twilio/twilio-csharp:apidefs-${API_DEFINITIONS_SHA}

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ docker-build:
 	docker tag twilio/twilio-csharp twilio/twilio-csharp:apidefs-${API_DEFINITIONS_SHA}
 
 docker-push:
-	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+	echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
 	docker push twilio/twilio-csharp:${TRAVIS_TAG}
-	docker push twilio/twilio-csharp:apidefs-${API_DEFINITIONS_TAG}
+	docker push twilio/twilio-csharp:apidefs-${API_DEFINITIONS_SHA}

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,14 @@ release: test
 
 docs:
 	doxygen Doxyfile
+
+API_DEFINITIONS_SHA=$(shell git log --oneline | grep Regenerated | head -n1 | cut -d ' ' -f 5)
+docker-build:
+	docker build -t twilio/twilio-csharp .
+	docker tag twilio/twilio-csharp twilio/twilio-csharp:${TRAVIS_TAG}
+	docker tag twilio/twilio-csharp twilio/twilio-csharp:${API_DEFINITIONS_SHA}
+
+docker-push:
+	docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+	docker push twilio/twilio-csharp:${TRAVIS_TAG}
+	docker push twilio/twilio-csharp:${API_DEFINITIONS_TAG}

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ package which is compatible with this version of the library.
 The alpha version is no longer necessary. All Twilio products are available in the main-line library.
 
 ## Docker Image
-The `Dockerfile` present in this repository and its respective `twilio/twilio-csharp` Docker image are used by Twilio for testing purposes only.
+The `Dockerfile` present in this repository and its respective `twilio/twilio-csharp` Docker image are currently used by Twilio for testing purposes only.
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ package which is compatible with this version of the library.
 ## Alpha Version
 The alpha version is no longer necessary. All Twilio products are available in the main-line library.
 
+## Docker Image
+The `Dockerfile` present in this repository and its respective `twilio/twilio-csharp` Docker image are used by Twilio for testing purposes only.
+
 ## Getting help
 
 If you need help installing or using the library, please contact Twilio Support at help@twilio.com first. Twilio's Support staff are well-versed in all of the Twilio Helper Libraries, and usually reply within 24 hours.


### PR DESCRIPTION
Hi there!

This PR adds the Dockerfile and related files to build the lib Docker image. This image will be used mainly by Tricorder to generate further Tricorder worker images with the specific lib version.

The tags used in the Docker images are the version (from the release tag) and the api-definitions SHA from the release.

TODO:
- [ ] Add Docker Hub credentials to the TravisCI env
- [ ] Merge and create a release for testing