### PR TITLE
Add a method for validating request body

### DIFF
--- a/test/Twilio.Test/Security/RequestValidatorTest.cs
+++ b/test/Twilio.Test/Security/RequestValidatorTest.cs
@@ -38,6 +38,13 @@ namespace Twilio.Tests.Security
         }
 
         [Test]
+        public void TestValidateFailsWhenIncorrect()
+        {
+            const string signature = "NOTRSOYDt4T1cUTdK1PDd93/VVr8B8=";
+            Assert.IsFalse(validator.Validate(url, parameters, signature), "Request should have failed validation but didn't");
+        }
+
+        [Test]
         public void TestValidateCollection()
         {
             const string signature = "RSOYDt4T1cUTdK1PDd93/VVr8B8=";
@@ -47,7 +54,7 @@ namespace Twilio.Tests.Security
         [Test]
         public void TestValidateBody()
         {
-            Assert.IsTrue(validator.ValidateBody(body, bodySignature));
+            Assert.IsTrue(validator.ValidateBody(body, bodySignature), "Request body validation failed");
         }
 
         [Test]
@@ -55,7 +62,13 @@ namespace Twilio.Tests.Security
         {
             parameters.Add("bodySHA256", bodySignature);
 
-            Assert.IsTrue(validator.Validate(url, parameters, body, "lhN9sMASXtkij921mMLP/O8yo04="));
+            Assert.IsTrue(validator.Validate(url, parameters, body, "lhN9sMASXtkij921mMLP/O8yo04="), "Request signature or body validation failed");
+        }
+
+        [Test]
+        public void TestValidateWithBodyWithoutSignature()
+        {
+            Assert.IsFalse(validator.Validate(url, parameters, body, "RSOYDt4T1cUTdK1PDd93/VVr8B8="), "Request signature or body validation failed");
         }
     }
 }

--- a/test/Twilio.Test/Security/RequestValidatorTest.cs
+++ b/test/Twilio.Test/Security/RequestValidatorTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Specialized;
 using NUnit.Framework;
 using Twilio.Security;
 
@@ -7,24 +8,54 @@ namespace Twilio.Tests.Security
     [TestFixture]
     public class RequestValidatorTest
     {
+        private readonly string url = "https://mycompany.com/myapp.php?foo=1&bar=2";
+        private readonly string body = "{\"property\": \"value\", \"boolean\": true}";
+        private readonly string bodySignature = "Ch/3Y02as7ldtcmi3+lBbkFQKyg6gMfPGWMmMvluZiA=";
+        private NameValueCollection parameters = new NameValueCollection();
+        private RequestValidator validator = new RequestValidator("12345");
+
+        public RequestValidatorTest()
+        {
+            // Intentionally out of alphabetical order
+            parameters.Add("CallSid", "CA1234567890ABCDE");
+            parameters.Add("From", "+14158675309");
+            parameters.Add("Digits", "1234");
+            parameters.Add("To", "+18005551212");
+            parameters.Add("Caller", "+14158675309");
+        }
 
         [Test]
-        public void TestValidate()
+        public void TestValidateDictionary()
         {
-            var validator = new RequestValidator("12345");
-
-            const string url = "https://mycompany.com/myapp.php?foo=1&bar=2";
-            var parameters = new Dictionary<string, string>
+            var dict = new Dictionary<string, string>();
+            foreach (var k in parameters.AllKeys)
             {
-                {"CallSid", "CA1234567890ABCDE"},
-                {"Caller", "+14158675309"},
-                {"Digits", "1234"},
-                {"From", "+14158675309"},
-                {"To", "+18005551212"}
-            };
+                dict.Add(k, parameters[k]);
+            }
 
             const string signature = "RSOYDt4T1cUTdK1PDd93/VVr8B8=";
             Assert.IsTrue(validator.Validate(url, parameters, signature), "Request does not match provided signature");
+        }
+
+        [Test]
+        public void TestValidateCollection()
+        {
+            const string signature = "RSOYDt4T1cUTdK1PDd93/VVr8B8=";
+            Assert.IsTrue(validator.Validate(url, parameters, signature), "Request does not match provided signature");
+        }
+
+        [Test]
+        public void TestValidateBody()
+        {
+            Assert.IsTrue(validator.ValidateBody(body, bodySignature));
+        }
+
+        [Test]
+        public void TestValidateWithBody()
+        {
+            parameters.Add("bodySHA256", bodySignature);
+
+            Assert.IsTrue(validator.Validate(url, parameters, body, "lhN9sMASXtkij921mMLP/O8yo04="));
         }
     }
 }


### PR DESCRIPTION
Adds two public methods: you can manually validate request body yourself, or you can pass in the request body to the Validator to validate based on the `bodySHA256` parameter.