### PR TITLE
Add helper method for testing if new SSL cert can be consumed

### DIFF
--- a/src/Twilio/Clients/TwilioRestClient.cs
+++ b/src/Twilio/Clients/TwilioRestClient.cs
@@ -111,7 +111,7 @@ namespace Twilio.Clients
             }
             return ProcessResponse(response);
         }
-        
+
         private static HttpClient DefaultClient()
         {
             return new SystemNetHttpClient();
@@ -142,7 +142,7 @@ namespace Twilio.Clients
                 restException = RestException.FromJson(response.Content);
             }
             catch (JsonReaderException) { /* Allow null check below to handle */ }
-            
+
             if (restException == null)
             {
                 throw new ApiException("Api Error: " + response.StatusCode + " - " + (response.Content ?? "[no content]"));
@@ -155,6 +155,40 @@ namespace Twilio.Clients
                 restException.MoreInfo
             );
         }
+
+        public static void ValidateSslCertificate()
+        {
+            ValidateSslCertificate(DefaultClient());
+        }
+
+        public static void ValidateSslCertificate(HttpClient testClient)
+        {
+            Request request = new Request("GET", "api", ":8443/", null);
+
+            try
+            {
+                Response response = testClient.MakeRequest(request);
+
+                if (!response.StatusCode.Equals(HttpStatusCode.OK))
+                {
+                    throw new CertificateValidationException(
+                        "Unexpected response from certificate endpoint",
+                        request,
+                        response
+                    );
+                }
+            }
+            catch (CertificateValidationException e) {
+                throw e;
+            }
+            catch (Exception e)
+            {
+                throw new CertificateValidationException(
+                    "Connection to api.twilio.com:8443 failed",
+                    e,
+                    request
+                );
+            }
+        }
     }
 }
-

--- a/src/Twilio/Clients/TwilioRestClient.cs
+++ b/src/Twilio/Clients/TwilioRestClient.cs
@@ -156,18 +156,30 @@ namespace Twilio.Clients
             );
         }
 
+        /// <summary>
+        /// Test that this application can use updated SSL certificates on
+        /// api.twilio.com:8443. It's a bit easier to call this method from
+        /// TwilioClient.ValidateSslCertificate().
+        /// </summary>
         public static void ValidateSslCertificate()
         {
             ValidateSslCertificate(DefaultClient());
         }
 
-        public static void ValidateSslCertificate(HttpClient testClient)
+        /// <summary>
+        /// Test that this application can use updated SSL certificates on
+        /// api.twilio.com:8443. Generally, you'll want to use the version of this
+        /// function that takes no parameters unless you have a reason not to.
+        /// </summary>
+        ///
+        /// <param name="client">HTTP Client to use for testing the request</param>
+        public static void ValidateSslCertificate(HttpClient client)
         {
             Request request = new Request("GET", "api", ":8443/", null);
 
             try
             {
-                Response response = testClient.MakeRequest(request);
+                Response response = client.MakeRequest(request);
 
                 if (!response.StatusCode.Equals(HttpStatusCode.OK))
                 {

--- a/src/Twilio/Exceptions/CertificateValidationException.cs
+++ b/src/Twilio/Exceptions/CertificateValidationException.cs
@@ -1,0 +1,46 @@
+using System;
+using Twilio.Http;
+
+namespace Twilio.Exceptions
+{
+    /// <summary>
+    /// Error thrown specifically when validating SSL connection
+    /// </summary>
+    public class CertificateValidationException : TwilioException
+    {
+        /// <summary>
+        /// Request object that triggered the exception
+        /// </summary>
+        public Request Request { get; }
+
+        /// <summary>
+        /// Response object that triggered the exception, if available
+        /// </summary>
+        public Response Response { get; }
+
+        /// <summary>
+        /// Construct a CertificateValidationException
+        /// </summary>
+        /// <param name="message">Error message</param>
+        /// <param name="request">The Request that triggered the exception</param>
+        /// <param name="response">The Response (if available) that triggered the exception</param>
+        public CertificateValidationException(string message, Request request, Response response)
+            : base(message)
+        {
+            Request = request;
+            Response = response;
+        }
+
+        /// <summary>
+        /// Construct a CertificateValidationException
+        /// </summary>
+        /// <param name="message">Error message</param>
+        /// <param name="exception">The parent exception</param>
+        /// <param name="request">The Request that triggered the exception</param>
+        public CertificateValidationException(string message, Exception exception, Request request)
+            : base(message, exception)
+        {
+            Request = request;
+        }
+    }
+}

--- a/src/Twilio/Twilio.cs
+++ b/src/Twilio/Twilio.cs
@@ -133,6 +133,14 @@ namespace Twilio
         {
             _restClient = null;
         }
+
+        /// <summary>
+        /// Validates that the Twilio Client can connect to api.twilio.com with
+        /// a new SSL certificate posted at api.twilio.com:8443
+        /// </summary>
+        public static void ValidateSslCertificate()
+        {
+            TwilioRestClient.ValidateSslCertificate();
+        }
     }
 }
-

--- a/test/Twilio.Test/Clients/TwilioRestClientTest.cs
+++ b/test/Twilio.Test/Clients/TwilioRestClientTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Net;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+using Twilio.Clients;
+using Twilio.Exceptions;
+using Twilio.Http;
+
+namespace Twilio.Tests.Clients
+{
+    [TestFixture]
+    public class TwilioRestClientTest
+    {
+        HttpClient client;
+
+        [SetUp]
+        public void Init()
+        {
+            client = Substitute.For<HttpClient>();
+        }
+
+        [Test]
+        public void TestValidSslCert()
+        {
+            client.MakeRequest(Arg.Any<Request>()).Returns(new Response(HttpStatusCode.OK, "OK"));
+            TwilioRestClient.ValidateSslCertificate(client);
+        }
+
+        [Test]
+        public void TestCantConnect()
+        {
+            // Exception type doesn't matter, just needs to match in IsInstanceOf below.
+            client.MakeRequest(Arg.Any<Request>()).Throws(new InvalidOperationException());
+
+            try {
+                TwilioRestClient.ValidateSslCertificate(client);
+                Assert.Fail("Should have failed ssl verification");
+            } catch (CertificateValidationException e) {
+                Assert.IsInstanceOf(typeof(InvalidOperationException), e.GetBaseException());
+                Assert.AreEqual("Connection to api.twilio.com:8443 failed", e.Message);
+                Assert.IsNull(e.Response);
+                Assert.IsNotNull(e.Request);
+            } catch (Exception) {
+                Assert.Fail("Threw an unknown exception");
+            }
+        }
+
+        [Test]
+        public void TestNotOkResponse()
+        {
+            client.MakeRequest(Arg.Any<Request>()).Returns(new Response(HttpStatusCode.SwitchingProtocols, "NOTOK"));
+
+            try {
+                TwilioRestClient.ValidateSslCertificate(client);
+                Assert.Fail("Should have failed ssl verification");
+            } catch (CertificateValidationException e) {
+                Assert.AreEqual("Unexpected response from certificate endpoint", e.Message);
+                Assert.IsNotNull(e.Response);
+                Assert.IsNotNull(e.Request);
+            } catch (Exception) {
+                Assert.Fail("Threw an unknown exception");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds a method at the top level TwilioClient that passes the request down to TwilioRestClient (which is where all the pipes were in place to make this happen).