### PR TITLE
POST doesn't receive params and body for body validation

### DIFF
--- a/src/Twilio/Security/RequestValidator.cs
+++ b/src/Twilio/Security/RequestValidator.cs
@@ -49,14 +49,20 @@ namespace Twilio.Security
             return SecureCompare(signature, expected);
         }
 
-        public bool Validate(string url, NameValueCollection parameters, string body, string expected)
+        public bool Validate(string url, string body, string expected)
         {
-            return Validate(url, ToDictionary(parameters), body, expected);
-        }
+            var paramString = new Uri(url).Query.TrimStart('?');
+            var bodyHash = "";
+            foreach (var param in paramString.Split('&'))
+            {
+                var split = param.Split('=');
+                if (split[0] == "bodySHA256")
+                {
+                    bodyHash = Uri.UnescapeDataString(split[1]);
+                }
+            }
 
-        public bool Validate(string url, IDictionary<string, string> parameters, string body, string expected)
-        {
-            return Validate(url, parameters, expected) && ValidateBody(body, parameters["bodySHA256"]);
+            return Validate(url, new Dictionary<string, string>(), expected) && ValidateBody(body, bodyHash);
         }
 
         public bool ValidateBody(string rawBody, string expected)

--- a/test/Twilio.Test/Twilio.Test.csproj
+++ b/test/Twilio.Test/Twilio.Test.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.6.0" />
     <PackageReference Include="NSubstitute" Version="2.0.0-rc" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="NUnitLite" Version="3.6.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">


### PR DESCRIPTION
Previously, we (I) assumed that we'd be passing in both parameters and request body. This is impossible, because parameters would _be_ the post body. This makes the logic either/or.