### PR TITLE
Update Twilio.csproj

### DIFF
--- a/src/Twilio/Twilio.csproj
+++ b/src/Twilio/Twilio.csproj
@@ -24,7 +24,7 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.4' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="[9.0.1,)" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.2" />


### PR DESCRIPTION
Remove the "explicit" v9 requirement 
As per https://docs.microsoft.com/en-us/nuget/reference/package-versioning if you use [9.0.1) this will mean only v9 can be used, current Newtonsoft.Json is 11

Not sure how many breaking changes occured between 9 and 11, going to test and see what happens.