### PR TITLE
Bump Newtonsoft.Json to 10.0.1 to try to fix #431

### DIFF
--- a/src/Twilio/Twilio.csproj
+++ b/src/Twilio/Twilio.csproj
@@ -24,16 +24,17 @@
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.4' ">1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="[9.0.1,)" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.2" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.2" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="1.1.2" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.2" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.2" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="1.1.2" />
@@ -43,6 +44,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <Reference Include="System" />
     <Reference Include="System.Web" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="JWT" Version="1.3.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Since these three Twilio dependencies require Newtonsoft.Json 10.0.1, we should require it as well:

```
    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.2" />
    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.2" />
    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="1.1.2" />
```

The hope is that this eliminates the need for binding redirects in a simple application that only has Twilio as a dependency.

See issue #431 