### PR TITLE
Remove unused dependency Microsoft.IdentityModel.Logging

### DIFF
--- a/src/Twilio/Twilio.csproj
+++ b/src/Twilio/Twilio.csproj
@@ -31,21 +31,18 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.2" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.2" />
-    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="1.1.2" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.3.0" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.3.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="5.3.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.1.2" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.1.2" />
-    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="1.1.2" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>


### PR DESCRIPTION
https://issues.corp.twilio.com/browse/DX-596
Remove unused dependency `Microsoft.IdentityModel.Logging` causing NuGet installation errors.