### PR TITLE
VIDEO-2338 TrackPriority.STANDARD

### DIFF
--- a/src/Twilio/Types/SubscribeRule.cs
+++ b/src/Twilio/Types/SubscribeRule.cs
@@ -39,7 +39,7 @@ namespace Twilio.Types
             public PriorityEnum() {}
 
             public static readonly PriorityEnum Low = new PriorityEnum("low");
-            public static readonly PriorityEnum Medium = new PriorityEnum("medium");
+            public static readonly PriorityEnum Standard = new PriorityEnum("standard");
             public static readonly PriorityEnum High = new PriorityEnum("high");
         }
 


### PR DESCRIPTION
Before GA of the Bandwidth Profile API, we have decided to change the TrackPriority to `STANDARD` as this more accurately describes the priority we're using.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
