### PR TITLE
Requesting pull to fix the thread safety issue in Twilio.Security.RequestValidator

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ deploy:
   api_key:
     secure: YZzoIwFHwZJOREzsekYHRptdAPDA9/OX1nHmwYRUr0c=
   skip_symbols: false
-  artifact: .\Twilio.*.nupkg
+  artifact: /Twilio\..*\.nupkg/
   on:
     branch: master
     APPVEYOR_REPO_TAG: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ branches:
 deploy:
   provider: NuGet
   api_key:
-    secure: YZzoIwFHwZJOREzsekYHRptdAPDA9/OX1nHmwYRUr0c=
+    secure: xi7DNs4Cj7fnCrY1m7l5LjwkTNe1hhchwUXQT6p6OX7TBLgpPf9uanNaYQ9Lbsi5
   skip_symbols: false
   artifact: /Twilio\..*\.nupkg/
   on:

--- a/src/Twilio/Converters/TwimlConverter.cs
+++ b/src/Twilio/Converters/TwimlConverter.cs
@@ -1,0 +1,52 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Twilio.Converters
+{
+    /// <summary>
+    /// Convert between strings and a Twiml
+    /// </summary>
+    public class TwimlConverter : JsonConverter
+    {
+        /// <summary>
+        /// Write value to JsonWriter
+        /// </summary>
+        /// <param name="writer">Writer to write to</param>
+        /// <param name="value">Value to write</param>
+        /// <param name="serializer">unused</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var t = JToken.FromObject(value.ToString());
+            t.WriteTo(writer);
+        }
+
+        /// <summary>
+        /// Convert a string to a Twiml
+        /// </summary>
+        /// <param name="reader">JsonReader to read from</param>
+        /// <param name="objectType">unused</param>
+        /// <param name="existingValue">unused</param>
+        /// <param name="serializer">unused</param>
+        /// <returns>Converted Twiml</returns>
+        public override object ReadJson(
+            JsonReader reader,
+            Type objectType,
+            object existingValue,
+            JsonSerializer serializer
+        )
+        {
+            return new Types.Twiml(reader.Value as string);
+        }
+
+        /// <summary>
+        /// Determines if an object converted to a Twiml
+        /// </summary>
+        /// <param name="objectType">Type of object</param>
+        /// <returns>true if an object can be converted; false otherwise</returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(Enum);
+        }
+    }
+}

--- a/src/Twilio/Properties/AssemblyInfo.cs
+++ b/src/Twilio/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.CompilerServices;
 
 internal class AssemblyInfomation
 {
-    public const string AssemblyInformationalVersion = "5.35.0";
+    public const string AssemblyInformationalVersion = "5.35.1";
 }

--- a/src/Twilio/Twilio.csproj
+++ b/src/Twilio/Twilio.csproj
@@ -7,7 +7,7 @@
     <Copyright>Copyright © Twilio</Copyright>
     <AssemblyTitle>Twilio</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>5.35.0</VersionPrefix>
+    <VersionPrefix>5.35.1</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <Authors>Twilio</Authors>

--- a/src/Twilio/Types/Twiml.cs
+++ b/src/Twilio/Types/Twiml.cs
@@ -1,0 +1,39 @@
+namespace Twilio.Types
+{
+    /// <summary>
+    /// Twiml endpoint
+    /// </summary>
+    public class Twiml
+    {
+        private readonly string _twiml;
+
+        /// <summary>
+        /// Create a new Twiml
+        /// </summary>
+        /// <param name="twiml">Twiml</param>
+        public Twiml(string twiml)
+        {
+            _twiml = twiml;
+        }
+
+        /// <summary>
+        /// Add implicit constructor for Twiml to make it assignable from string
+        /// </summary>
+        /// <param name="twiml">Twiml</param>
+        /// <returns></returns>
+        public static implicit operator Twiml(string twiml)
+        {
+            return new Twiml(twiml);
+        }
+
+        /// <summary>
+        /// Convert to string
+        /// </summary>
+        /// <returns>String representation</returns>
+        public override string ToString()
+        {
+            return _twiml;
+        }
+    }
+}
+


### PR DESCRIPTION
Found an [issue](https://github.com/twilio/twilio-csharp/issues/466) in 'Twilio.Security.RequestValidator'. 

Our services were impacted by the issue. We found a workaround by doing a re-init of the RequestValidator object, but we're now in a development cycle and finding that another issue is also related. Even with a reinit, we're seeing ObjectDisposed exceptions thrown by the member objects, which is causing some of our state transfers to fail unexpectedly.

Would like an opportunity to get in here and fix the issue.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
