### PR TITLE
chore: drop the unneeded client region when constructing requests

### DIFF
--- a/src/Twilio/Base/Page.cs
+++ b/src/Twilio/Base/Page.cs
@@ -67,9 +67,8 @@ namespace Twilio.Base
         /// Generate the first page URL
         /// </summary>
         /// <param name="domain">Twilio subdomain</param>
-        /// <param name="region">Twilio region</param>
         /// <returns>URL for the first page of results</returns>
-        public string GetFirstPageUrl(Domain domain, string region = null)
+        public string GetFirstPageUrl(Domain domain)
         {
             return _firstPageUrl ?? UrlFromUri(domain, _firstPageUri);
         }
@@ -78,9 +77,8 @@ namespace Twilio.Base
         /// Get the next page URL
         /// </summary>
         /// <param name="domain">Twilio subdomain</param>
-        /// <param name="region">Twilio region</param>
         /// <returns>URL for the next page of results</returns>
-        public string GetNextPageUrl(Domain domain, string region = null)
+        public string GetNextPageUrl(Domain domain)
         {
             return _nextPageUrl ?? UrlFromUri(domain, _nextPageUri);
         }
@@ -89,9 +87,8 @@ namespace Twilio.Base
         /// Get the previous page URL
         /// </summary>
         /// <param name="domain">Twilio subdomain</param>
-        /// <param name="region">Twilio region</param>
         /// <returns>URL for the previous page of results</returns>
-        public string GetPreviousPageUrl(Domain domain, string region = null)
+        public string GetPreviousPageUrl(Domain domain)
         {
             return _previousPageUrl ?? UrlFromUri(domain, _previousPageUri);
         }
@@ -100,9 +97,8 @@ namespace Twilio.Base
         /// Get the URL for the current page
         /// </summary>
         /// <param name="domain">Twilio subdomain</param>
-        /// <param name="region">Twilio region</param>
         /// <returns>URL for the current page of results</returns>
-        public string GetUrl(Domain domain, string region = null)
+        public string GetUrl(Domain domain)
         {
             return _url ?? UrlFromUri(domain, _uri);
         }

--- a/src/Twilio/Rest/Accounts/V1/Credential/AwsResource.cs
+++ b/src/Twilio/Rest/Accounts/V1/Credential/AwsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Accounts.V1.Credential
                 HttpMethod.Get,
                 Rest.Domain.Accounts,
                 "/v1/Credentials/AWS",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -125,10 +124,7 @@ namespace Twilio.Rest.Accounts.V1.Credential
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Accounts,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Accounts)
             );
 
             var response = client.Request(request);
@@ -145,10 +141,7 @@ namespace Twilio.Rest.Accounts.V1.Credential
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Accounts,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Accounts)
             );
 
             var response = client.Request(request);
@@ -161,7 +154,6 @@ namespace Twilio.Rest.Accounts.V1.Credential
                 HttpMethod.Post,
                 Rest.Domain.Accounts,
                 "/v1/Credentials/AWS",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -239,7 +231,6 @@ namespace Twilio.Rest.Accounts.V1.Credential
                 HttpMethod.Get,
                 Rest.Domain.Accounts,
                 "/v1/Credentials/AWS/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -306,7 +297,6 @@ namespace Twilio.Rest.Accounts.V1.Credential
                 HttpMethod.Post,
                 Rest.Domain.Accounts,
                 "/v1/Credentials/AWS/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -376,7 +366,6 @@ namespace Twilio.Rest.Accounts.V1.Credential
                 HttpMethod.Delete,
                 Rest.Domain.Accounts,
                 "/v1/Credentials/AWS/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Accounts/V1/Credential/PublicKeyResource.cs
+++ b/src/Twilio/Rest/Accounts/V1/Credential/PublicKeyResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Accounts.V1.Credential
                 HttpMethod.Get,
                 Rest.Domain.Accounts,
                 "/v1/Credentials/PublicKeys",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -125,10 +124,7 @@ namespace Twilio.Rest.Accounts.V1.Credential
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Accounts,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Accounts)
             );
 
             var response = client.Request(request);
@@ -145,10 +141,7 @@ namespace Twilio.Rest.Accounts.V1.Credential
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Accounts,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Accounts)
             );
 
             var response = client.Request(request);
@@ -161,7 +154,6 @@ namespace Twilio.Rest.Accounts.V1.Credential
                 HttpMethod.Post,
                 Rest.Domain.Accounts,
                 "/v1/Credentials/PublicKeys",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -237,7 +229,6 @@ namespace Twilio.Rest.Accounts.V1.Credential
                 HttpMethod.Get,
                 Rest.Domain.Accounts,
                 "/v1/Credentials/PublicKeys/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -304,7 +295,6 @@ namespace Twilio.Rest.Accounts.V1.Credential
                 HttpMethod.Post,
                 Rest.Domain.Accounts,
                 "/v1/Credentials/PublicKeys/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -374,7 +364,6 @@ namespace Twilio.Rest.Accounts.V1.Credential
                 HttpMethod.Delete,
                 Rest.Domain.Accounts,
                 "/v1/Credentials/PublicKeys/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Address/DependentPhoneNumberResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Address/DependentPhoneNumberResource.cs
@@ -55,7 +55,6 @@ namespace Twilio.Rest.Api.V2010.Account.Address
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Addresses/" + options.PathAddressSid + "/DependentPhoneNumbers.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -164,10 +163,7 @@ namespace Twilio.Rest.Api.V2010.Account.Address
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -185,10 +181,7 @@ namespace Twilio.Rest.Api.V2010.Account.Address
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/AddressResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/AddressResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Addresses.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -130,7 +129,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Addresses/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -200,7 +198,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Addresses/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -270,7 +267,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Addresses/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -374,7 +370,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Addresses.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -489,10 +484,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -509,10 +501,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/ApplicationResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/ApplicationResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Applications.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -154,7 +153,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Applications/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -224,7 +222,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Applications/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -296,7 +293,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Applications.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -403,10 +399,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -423,10 +416,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -439,7 +429,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Applications/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/AuthorizedConnectAppResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/AuthorizedConnectAppResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AuthorizedConnectApps/" + options.PathConnectAppSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -113,7 +112,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AuthorizedConnectApps.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -218,10 +216,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -239,10 +234,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/LocalResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/LocalResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AvailablePhoneNumbers/" + options.PathCountryCode + "/Local.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -214,10 +213,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -234,10 +230,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/MachineToMachineResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/MachineToMachineResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AvailablePhoneNumbers/" + options.PathCountryCode + "/MachineToMachine.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -215,10 +214,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -236,10 +232,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/MobileResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/MobileResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AvailablePhoneNumbers/" + options.PathCountryCode + "/Mobile.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -214,10 +213,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -234,10 +230,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/NationalResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/NationalResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AvailablePhoneNumbers/" + options.PathCountryCode + "/National.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -214,10 +213,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -234,10 +230,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/SharedCostResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/SharedCostResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AvailablePhoneNumbers/" + options.PathCountryCode + "/SharedCost.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -214,10 +213,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -234,10 +230,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/TollFreeResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/TollFreeResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AvailablePhoneNumbers/" + options.PathCountryCode + "/TollFree.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -214,10 +213,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -234,10 +230,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/VoipResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountry/VoipResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AvailablePhoneNumbers/" + options.PathCountryCode + "/Voip.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -214,10 +213,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -234,10 +230,7 @@ namespace Twilio.Rest.Api.V2010.Account.AvailablePhoneNumberCountry
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountryResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/AvailablePhoneNumberCountryResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AvailablePhoneNumbers.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -133,10 +132,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -154,10 +150,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -170,7 +163,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/AvailablePhoneNumbers/" + options.PathCountryCode + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/BalanceResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/BalanceResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Balance.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Call/FeedbackResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Call/FeedbackResource.cs
@@ -46,7 +46,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Feedback.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -126,7 +125,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Feedback.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -198,7 +196,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Feedback.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Call/FeedbackSummaryResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Call/FeedbackSummaryResource.cs
@@ -42,7 +42,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/FeedbackSummary.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -130,7 +129,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/FeedbackSummary/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -202,7 +200,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/FeedbackSummary/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Call/NotificationResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Call/NotificationResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Notifications/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Notifications.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -226,10 +224,7 @@ namespace Twilio.Rest.Api.V2010.Account.Call
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -246,10 +241,7 @@ namespace Twilio.Rest.Api.V2010.Account.Call
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Call/PaymentResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Call/PaymentResource.cs
@@ -100,7 +100,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Payments.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -240,7 +239,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Payments/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Call/RecordingResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Call/RecordingResource.cs
@@ -62,7 +62,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Recordings.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -156,7 +155,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Recordings/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -244,7 +242,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Recordings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -320,7 +317,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Recordings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -396,7 +392,6 @@ namespace Twilio.Rest.Api.V2010.Account.Call
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathCallSid + "/Recordings.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -515,10 +510,7 @@ namespace Twilio.Rest.Api.V2010.Account.Call
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -535,10 +527,7 @@ namespace Twilio.Rest.Api.V2010.Account.Call
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/CallResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/CallResource.cs
@@ -74,7 +74,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -282,7 +281,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -356,7 +354,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -426,7 +423,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -569,10 +565,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -589,10 +582,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -605,7 +595,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Calls/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Conference/ParticipantResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Conference/ParticipantResource.cs
@@ -44,7 +44,6 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathConferenceSid + "/Participants/" + options.PathCallSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -120,7 +119,6 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathConferenceSid + "/Participants/" + options.PathCallSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -248,7 +246,6 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathConferenceSid + "/Participants.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -472,7 +469,6 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathConferenceSid + "/Participants/" + options.PathCallSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -548,7 +544,6 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathConferenceSid + "/Participants.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -667,10 +662,7 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -687,10 +679,7 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Conference/RecordingResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Conference/RecordingResource.cs
@@ -62,7 +62,6 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathConferenceSid + "/Recordings/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -150,7 +149,6 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathConferenceSid + "/Recordings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -226,7 +224,6 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathConferenceSid + "/Recordings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -302,7 +299,6 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathConferenceSid + "/Recordings.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -421,10 +417,7 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -441,10 +434,7 @@ namespace Twilio.Rest.Api.V2010.Account.Conference
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/ConferenceResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/ConferenceResource.cs
@@ -53,7 +53,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -123,7 +122,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -258,10 +256,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -278,10 +273,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -294,7 +286,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Conferences/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/ConnectAppResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/ConnectAppResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/ConnectApps/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/ConnectApps/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -214,7 +212,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/ConnectApps.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -317,10 +314,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -337,10 +331,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -353,7 +344,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/ConnectApps/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/AssignedAddOn/AssignedAddOnExtensionResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/AssignedAddOn/AssignedAddOnExtensionResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber.AssignedAddOn
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/" + options.PathResourceSid + "/AssignedAddOns/" + options.PathAssignedAddOnSid + "/Extensions/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -109,7 +108,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber.AssignedAddOn
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/" + options.PathResourceSid + "/AssignedAddOns/" + options.PathAssignedAddOnSid + "/Extensions.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -222,10 +220,7 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber.AssignedAddOn
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -243,10 +238,7 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber.AssignedAddOn
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/AssignedAddOnResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/AssignedAddOnResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/" + options.PathResourceSid + "/AssignedAddOns/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -104,7 +103,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/" + options.PathResourceSid + "/AssignedAddOns.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -212,10 +210,7 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -232,10 +227,7 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -248,7 +240,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/" + options.PathResourceSid + "/AssignedAddOns.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -324,7 +315,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/" + options.PathResourceSid + "/AssignedAddOns/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/LocalResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/LocalResource.cs
@@ -68,7 +68,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/Local.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -189,10 +188,7 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -209,10 +205,7 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -225,7 +218,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/Local.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/MobileResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/MobileResource.cs
@@ -68,7 +68,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/Mobile.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -189,10 +188,7 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -209,10 +205,7 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -225,7 +218,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/Mobile.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/TollFreeResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumber/TollFreeResource.cs
@@ -68,7 +68,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/TollFree.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -189,10 +188,7 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -209,10 +205,7 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -225,7 +218,6 @@ namespace Twilio.Rest.Api.V2010.Account.IncomingPhoneNumber
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/TollFree.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumberResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/IncomingPhoneNumberResource.cs
@@ -68,7 +68,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -233,7 +232,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -306,7 +304,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -376,7 +373,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -499,10 +495,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -520,10 +513,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -536,7 +526,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/IncomingPhoneNumbers.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/KeyResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/KeyResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Keys/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Keys/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -172,7 +170,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Keys/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -242,7 +239,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Keys.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -345,10 +341,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -365,10 +358,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Message/FeedbackResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Message/FeedbackResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Api.V2010.Account.Message
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Messages/" + options.PathMessageSid + "/Feedback.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Message/MediaResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Message/MediaResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Message
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Messages/" + options.PathMessageSid + "/Media/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.Api.V2010.Account.Message
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Messages/" + options.PathMessageSid + "/Media/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -178,7 +176,6 @@ namespace Twilio.Rest.Api.V2010.Account.Message
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Messages/" + options.PathMessageSid + "/Media.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -297,10 +294,7 @@ namespace Twilio.Rest.Api.V2010.Account.Message
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -317,10 +311,7 @@ namespace Twilio.Rest.Api.V2010.Account.Message
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/MessageResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/MessageResource.cs
@@ -101,7 +101,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Messages.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -241,7 +240,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Messages/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -311,7 +309,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Messages/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -381,7 +378,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Messages.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -504,10 +500,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -524,10 +517,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -540,7 +530,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Messages/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/NewKeyResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/NewKeyResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Keys.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/NewSigningKeyResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/NewSigningKeyResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SigningKeys.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/NotificationResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/NotificationResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Notifications/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -98,7 +97,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Notifications.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -218,10 +216,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -238,10 +233,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/OutgoingCallerIdResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/OutgoingCallerIdResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/OutgoingCallerIds/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -98,7 +97,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/OutgoingCallerIds/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -174,7 +172,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/OutgoingCallerIds/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -244,7 +241,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/OutgoingCallerIds.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -356,10 +352,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -377,10 +370,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Queue/MemberResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Queue/MemberResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Queue
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Queues/" + options.PathQueueSid + "/Members/" + options.PathCallSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.Api.V2010.Account.Queue
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Queues/" + options.PathQueueSid + "/Members/" + options.PathCallSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -186,7 +184,6 @@ namespace Twilio.Rest.Api.V2010.Account.Queue
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Queues/" + options.PathQueueSid + "/Members.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -293,10 +290,7 @@ namespace Twilio.Rest.Api.V2010.Account.Queue
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -313,10 +307,7 @@ namespace Twilio.Rest.Api.V2010.Account.Queue
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/QueueResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/QueueResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Queues/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Queues/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -176,7 +174,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Queues/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -246,7 +243,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Queues.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -349,10 +345,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -369,10 +362,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -385,7 +375,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Queues.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Recording/AddOnResult/PayloadResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Recording/AddOnResult/PayloadResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Recording.AddOnResult
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathReferenceSid + "/AddOnResults/" + options.PathAddOnResultSid + "/Payloads/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -108,7 +107,6 @@ namespace Twilio.Rest.Api.V2010.Account.Recording.AddOnResult
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathReferenceSid + "/AddOnResults/" + options.PathAddOnResultSid + "/Payloads.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -221,10 +219,7 @@ namespace Twilio.Rest.Api.V2010.Account.Recording.AddOnResult
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -241,10 +236,7 @@ namespace Twilio.Rest.Api.V2010.Account.Recording.AddOnResult
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -257,7 +249,6 @@ namespace Twilio.Rest.Api.V2010.Account.Recording.AddOnResult
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathReferenceSid + "/AddOnResults/" + options.PathAddOnResultSid + "/Payloads/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Recording/AddOnResultResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Recording/AddOnResultResource.cs
@@ -46,7 +46,6 @@ namespace Twilio.Rest.Api.V2010.Account.Recording
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathReferenceSid + "/AddOnResults/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -122,7 +121,6 @@ namespace Twilio.Rest.Api.V2010.Account.Recording
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathReferenceSid + "/AddOnResults.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -229,10 +227,7 @@ namespace Twilio.Rest.Api.V2010.Account.Recording
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -249,10 +244,7 @@ namespace Twilio.Rest.Api.V2010.Account.Recording
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -265,7 +257,6 @@ namespace Twilio.Rest.Api.V2010.Account.Recording
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathReferenceSid + "/AddOnResults/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Recording/TranscriptionResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Recording/TranscriptionResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Api.V2010.Account.Recording
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathRecordingSid + "/Transcriptions/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -117,7 +116,6 @@ namespace Twilio.Rest.Api.V2010.Account.Recording
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathRecordingSid + "/Transcriptions/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -193,7 +191,6 @@ namespace Twilio.Rest.Api.V2010.Account.Recording
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathRecordingSid + "/Transcriptions.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -301,10 +298,7 @@ namespace Twilio.Rest.Api.V2010.Account.Recording
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -321,10 +315,7 @@ namespace Twilio.Rest.Api.V2010.Account.Recording
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/RecordingResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/RecordingResource.cs
@@ -62,7 +62,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -132,7 +131,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -202,7 +200,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Recordings.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -325,10 +322,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -345,10 +339,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/ShortCodeResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/ShortCodeResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SMS/ShortCodes/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SMS/ShortCodes/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -192,7 +190,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SMS/ShortCodes.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -303,10 +300,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -323,10 +317,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/SigningKeyResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/SigningKeyResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SigningKeys/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SigningKeys/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -172,7 +170,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SigningKeys/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -242,7 +239,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SigningKeys.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -345,10 +341,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -365,10 +358,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Sip/CredentialList/CredentialResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Sip/CredentialList/CredentialResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.CredentialList
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/CredentialLists/" + options.PathCredentialListSid + "/Credentials.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -135,10 +134,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.CredentialList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -155,10 +151,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.CredentialList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -171,7 +164,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.CredentialList
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/CredentialLists/" + options.PathCredentialListSid + "/Credentials.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -253,7 +245,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.CredentialList
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/CredentialLists/" + options.PathCredentialListSid + "/Credentials/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -331,7 +322,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.CredentialList
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/CredentialLists/" + options.PathCredentialListSid + "/Credentials/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -413,7 +403,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.CredentialList
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/CredentialLists/" + options.PathCredentialListSid + "/Credentials/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Sip/CredentialListResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Sip/CredentialListResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/CredentialLists.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -130,10 +129,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -150,10 +146,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -166,7 +159,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/CredentialLists.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -238,7 +230,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/CredentialLists/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -310,7 +301,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/CredentialLists/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -386,7 +376,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/CredentialLists/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Sip/Domain/AuthTypes/AuthTypeCalls/AuthCallsCredentialListMappingResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Sip/Domain/AuthTypes/AuthTypeCalls/AuthCallsCredentialListMappingResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Calls/CredentialListMappings.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -104,7 +103,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Calls/CredentialListMappings.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -213,10 +211,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -234,10 +229,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -251,7 +243,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Calls/CredentialListMappings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -329,7 +320,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Calls/CredentialListMappings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Sip/Domain/AuthTypes/AuthTypeCalls/AuthCallsIpAccessControlListMappingResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Sip/Domain/AuthTypes/AuthTypeCalls/AuthCallsIpAccessControlListMappingResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Calls/IpAccessControlListMappings.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -105,7 +104,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Calls/IpAccessControlListMappings.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -214,10 +212,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -235,10 +230,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -252,7 +244,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Calls/IpAccessControlListMappings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -330,7 +321,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeCalls
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Calls/IpAccessControlListMappings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Sip/Domain/AuthTypes/AuthTypeRegistrations/AuthRegistrationsCredentialListMappingResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Sip/Domain/AuthTypes/AuthTypeRegistrations/AuthRegistrationsCredentialListMappingResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeRegistratio
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Registrations/CredentialListMappings.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -105,7 +104,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeRegistratio
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Registrations/CredentialListMappings.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -215,10 +213,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeRegistratio
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -236,10 +231,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeRegistratio
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -253,7 +245,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeRegistratio
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Registrations/CredentialListMappings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -331,7 +322,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain.AuthTypes.AuthTypeRegistratio
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/Auth/Registrations/CredentialListMappings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Sip/Domain/CredentialListMappingResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Sip/Domain/CredentialListMappingResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/CredentialListMappings.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -107,7 +106,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/CredentialListMappings.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -216,10 +214,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -237,10 +232,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -253,7 +245,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/CredentialListMappings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -330,7 +321,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/CredentialListMappings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Sip/Domain/IpAccessControlListMappingResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Sip/Domain/IpAccessControlListMappingResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/IpAccessControlListMappings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -103,7 +102,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/IpAccessControlListMappings.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -180,7 +178,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/IpAccessControlListMappings.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -289,10 +286,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -310,10 +304,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -326,7 +317,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.Domain
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathDomainSid + "/IpAccessControlListMappings/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Sip/DomainResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Sip/DomainResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -129,10 +128,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -149,10 +145,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -165,7 +158,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -277,7 +269,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -347,7 +338,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -463,7 +453,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/Domains/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlList/IpAddressResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlList/IpAddressResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.IpAccessControlList
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/IpAccessControlLists/" + options.PathIpAccessControlListSid + "/IpAddresses.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -135,10 +134,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.IpAccessControlList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -155,10 +151,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.IpAccessControlList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -171,7 +164,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.IpAccessControlList
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/IpAccessControlLists/" + options.PathIpAccessControlListSid + "/IpAddresses.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -261,7 +253,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.IpAccessControlList
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/IpAccessControlLists/" + options.PathIpAccessControlListSid + "/IpAddresses/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -339,7 +330,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.IpAccessControlList
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/IpAccessControlLists/" + options.PathIpAccessControlListSid + "/IpAddresses/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -433,7 +423,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip.IpAccessControlList
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/IpAccessControlLists/" + options.PathIpAccessControlListSid + "/IpAddresses/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlListResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Sip/IpAccessControlListResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/IpAccessControlLists.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -131,10 +130,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -152,10 +148,7 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -168,7 +161,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/IpAccessControlLists.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -241,7 +233,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/IpAccessControlLists/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -314,7 +305,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/IpAccessControlLists/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -391,7 +381,6 @@ namespace Twilio.Rest.Api.V2010.Account.Sip
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/SIP/IpAccessControlLists/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/TokenResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/TokenResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Tokens.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/Account/TranscriptionResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/TranscriptionResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Transcriptions/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -113,7 +112,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Transcriptions/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -183,7 +181,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Transcriptions.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -287,10 +284,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -307,10 +301,7 @@ namespace Twilio.Rest.Api.V2010.Account
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Usage/Record/AllTimeResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Usage/Record/AllTimeResource.cs
@@ -283,7 +283,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Records/AllTime.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -402,10 +401,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -422,10 +418,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Usage/Record/DailyResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Usage/Record/DailyResource.cs
@@ -283,7 +283,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Records/Daily.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -402,10 +401,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -422,10 +418,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Usage/Record/LastMonthResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Usage/Record/LastMonthResource.cs
@@ -283,7 +283,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Records/LastMonth.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -402,10 +401,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -422,10 +418,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Usage/Record/MonthlyResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Usage/Record/MonthlyResource.cs
@@ -283,7 +283,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Records/Monthly.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -402,10 +401,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -422,10 +418,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Usage/Record/ThisMonthResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Usage/Record/ThisMonthResource.cs
@@ -283,7 +283,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Records/ThisMonth.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -402,10 +401,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -422,10 +418,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Usage/Record/TodayResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Usage/Record/TodayResource.cs
@@ -283,7 +283,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Records/Today.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -402,10 +401,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -422,10 +418,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Usage/Record/YearlyResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Usage/Record/YearlyResource.cs
@@ -283,7 +283,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Records/Yearly.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -402,10 +401,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -422,10 +418,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Usage/Record/YesterdayResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Usage/Record/YesterdayResource.cs
@@ -283,7 +283,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Records/Yesterday.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -402,10 +401,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -422,10 +418,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage.Record
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Usage/RecordResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Usage/RecordResource.cs
@@ -283,7 +283,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Records.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -402,10 +401,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -422,10 +418,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/Usage/TriggerResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/Usage/TriggerResource.cs
@@ -312,7 +312,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Triggers/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -382,7 +381,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Triggers/" + options.PathSid + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -466,7 +464,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage
                 HttpMethod.Delete,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Triggers/" + options.PathSid + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -536,7 +533,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Triggers.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -632,7 +628,6 @@ namespace Twilio.Rest.Api.V2010.Account.Usage
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/Usage/Triggers.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -747,10 +742,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -767,10 +759,7 @@ namespace Twilio.Rest.Api.V2010.Account.Usage
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Api/V2010/Account/ValidationRequestResource.cs
+++ b/src/Twilio/Rest/Api/V2010/Account/ValidationRequestResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Api.V2010.Account
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathAccountSid ?? client.AccountSid) + "/OutgoingCallerIds.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Api/V2010/AccountResource.cs
+++ b/src/Twilio/Rest/Api/V2010/AccountResource.cs
@@ -54,7 +54,6 @@ namespace Twilio.Rest.Api.V2010
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts.json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -121,7 +120,6 @@ namespace Twilio.Rest.Api.V2010
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathSid ?? client.AccountSid) + ".json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -188,7 +186,6 @@ namespace Twilio.Rest.Api.V2010
                 HttpMethod.Get,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts.json",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -295,10 +292,7 @@ namespace Twilio.Rest.Api.V2010
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -315,10 +309,7 @@ namespace Twilio.Rest.Api.V2010
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Api,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Api)
             );
 
             var response = client.Request(request);
@@ -331,7 +322,6 @@ namespace Twilio.Rest.Api.V2010
                 HttpMethod.Post,
                 Rest.Domain.Api,
                 "/2010-04-01/Accounts/" + (options.PathSid ?? client.AccountSid) + ".json",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Authy/V1/FormResource.cs
+++ b/src/Twilio/Rest/Authy/V1/FormResource.cs
@@ -44,7 +44,6 @@ namespace Twilio.Rest.Authy.V1
                 HttpMethod.Get,
                 Rest.Domain.Authy,
                 "/v1/Forms/" + options.PathFormType + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Authy/V1/Service/Entity/Factor/ChallengeResource.cs
+++ b/src/Twilio/Rest/Authy/V1/Service/Entity/Factor/ChallengeResource.cs
@@ -74,7 +74,6 @@ namespace Twilio.Rest.Authy.V1.Service.Entity.Factor
                 HttpMethod.Post,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "/Factors/" + options.PathFactorSid + "/Challenges",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -162,7 +161,6 @@ namespace Twilio.Rest.Authy.V1.Service.Entity.Factor
                 HttpMethod.Delete,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "/Factors/" + options.PathFactorSid + "/Challenges/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -242,7 +240,6 @@ namespace Twilio.Rest.Authy.V1.Service.Entity.Factor
                 HttpMethod.Get,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "/Factors/" + options.PathFactorSid + "/Challenges/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -322,7 +319,6 @@ namespace Twilio.Rest.Authy.V1.Service.Entity.Factor
                 HttpMethod.Get,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "/Factors/" + options.PathFactorSid + "/Challenges",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -437,10 +433,7 @@ namespace Twilio.Rest.Authy.V1.Service.Entity.Factor
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Authy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Authy)
             );
 
             var response = client.Request(request);
@@ -457,10 +450,7 @@ namespace Twilio.Rest.Authy.V1.Service.Entity.Factor
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Authy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Authy)
             );
 
             var response = client.Request(request);
@@ -473,7 +463,6 @@ namespace Twilio.Rest.Authy.V1.Service.Entity.Factor
                 HttpMethod.Post,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "/Factors/" + options.PathFactorSid + "/Challenges/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Authy/V1/Service/Entity/FactorResource.cs
+++ b/src/Twilio/Rest/Authy/V1/Service/Entity/FactorResource.cs
@@ -58,7 +58,6 @@ namespace Twilio.Rest.Authy.V1.Service.Entity
                 HttpMethod.Post,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "/Factors",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -146,7 +145,6 @@ namespace Twilio.Rest.Authy.V1.Service.Entity
                 HttpMethod.Delete,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "/Factors/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -222,7 +220,6 @@ namespace Twilio.Rest.Authy.V1.Service.Entity
                 HttpMethod.Get,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "/Factors/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -298,7 +295,6 @@ namespace Twilio.Rest.Authy.V1.Service.Entity
                 HttpMethod.Get,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "/Factors",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -405,10 +401,7 @@ namespace Twilio.Rest.Authy.V1.Service.Entity
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Authy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Authy)
             );
 
             var response = client.Request(request);
@@ -425,10 +418,7 @@ namespace Twilio.Rest.Authy.V1.Service.Entity
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Authy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Authy)
             );
 
             var response = client.Request(request);
@@ -441,7 +431,6 @@ namespace Twilio.Rest.Authy.V1.Service.Entity
                 HttpMethod.Post,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "/Factors/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Authy/V1/Service/EntityResource.cs
+++ b/src/Twilio/Rest/Authy/V1/Service/EntityResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Authy.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Authy.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -169,7 +167,6 @@ namespace Twilio.Rest.Authy.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -239,7 +236,6 @@ namespace Twilio.Rest.Authy.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathServiceSid + "/Entities",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -342,10 +338,7 @@ namespace Twilio.Rest.Authy.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Authy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Authy)
             );
 
             var response = client.Request(request);
@@ -362,10 +355,7 @@ namespace Twilio.Rest.Authy.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Authy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Authy)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Authy/V1/ServiceResource.cs
+++ b/src/Twilio/Rest/Authy/V1/ServiceResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Authy.V1
                 HttpMethod.Post,
                 Rest.Domain.Authy,
                 "/v1/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Authy.V1
                 HttpMethod.Delete,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -165,7 +163,6 @@ namespace Twilio.Rest.Authy.V1
                 HttpMethod.Get,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -232,7 +229,6 @@ namespace Twilio.Rest.Authy.V1
                 HttpMethod.Get,
                 Rest.Domain.Authy,
                 "/v1/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -331,10 +327,7 @@ namespace Twilio.Rest.Authy.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Authy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Authy)
             );
 
             var response = client.Request(request);
@@ -351,10 +344,7 @@ namespace Twilio.Rest.Authy.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Authy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Authy)
             );
 
             var response = client.Request(request);
@@ -367,7 +357,6 @@ namespace Twilio.Rest.Authy.V1
                 HttpMethod.Post,
                 Rest.Domain.Authy,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/DefaultsResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/DefaultsResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Defaults",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Defaults",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/DialogueResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/DialogueResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Dialogues/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/ExportAssistantResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/ExportAssistantResource.cs
@@ -43,7 +43,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Export",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/FieldType/FieldValueResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/FieldType/FieldValueResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.FieldType
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathFieldTypeSid + "/FieldValues/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -107,7 +106,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.FieldType
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathFieldTypeSid + "/FieldValues",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -220,10 +218,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.FieldType
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -240,10 +235,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.FieldType
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -256,7 +248,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.FieldType
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathFieldTypeSid + "/FieldValues",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -342,7 +333,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.FieldType
                 HttpMethod.Delete,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathFieldTypeSid + "/FieldValues/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/FieldTypeResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/FieldTypeResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/FieldTypes",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -202,10 +200,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -222,10 +217,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -238,7 +230,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/FieldTypes",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -314,7 +305,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -394,7 +384,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Delete,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/ModelBuildResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/ModelBuildResource.cs
@@ -46,7 +46,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/ModelBuilds/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -116,7 +115,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/ModelBuilds",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -219,10 +217,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -239,10 +234,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -255,7 +247,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/ModelBuilds",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -333,7 +324,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/ModelBuilds/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -409,7 +399,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Delete,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/ModelBuilds/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/QueryResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/QueryResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Queries/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Queries",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -216,10 +214,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -236,10 +231,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -252,7 +244,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Queries",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -336,7 +327,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Queries/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -416,7 +406,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Delete,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Queries/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/StyleSheetResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/StyleSheetResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/StyleSheet",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/StyleSheet",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/Task/FieldResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/Task/FieldResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Fields/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -109,7 +108,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Fields",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -220,10 +218,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -240,10 +235,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -256,7 +248,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Fields",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -340,7 +331,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Delete,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Fields/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/Task/SampleResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/Task/SampleResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Samples/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -107,7 +106,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Samples",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -220,10 +218,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -240,10 +235,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -256,7 +248,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Samples",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -342,7 +333,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Samples/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -432,7 +422,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Delete,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Samples/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/Task/TaskActionsResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/Task/TaskActionsResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Actions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -101,7 +100,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Actions",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/Task/TaskStatisticsResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/Task/TaskStatisticsResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Statistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/TaskResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/TaskResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -202,10 +200,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -222,10 +217,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -238,7 +230,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -324,7 +315,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -414,7 +404,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Delete,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/Assistant/WebhookResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/Assistant/WebhookResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Webhooks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -202,10 +200,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -222,10 +217,7 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -238,7 +230,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Webhooks",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -322,7 +313,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -410,7 +400,6 @@ namespace Twilio.Rest.Autopilot.V1.Assistant
                 HttpMethod.Delete,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathAssistantSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Autopilot/V1/AssistantResource.cs
+++ b/src/Twilio/Rest/Autopilot/V1/AssistantResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Autopilot.V1
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Autopilot.V1
                 HttpMethod.Get,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -195,10 +193,7 @@ namespace Twilio.Rest.Autopilot.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -215,10 +210,7 @@ namespace Twilio.Rest.Autopilot.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Autopilot,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Autopilot)
             );
 
             var response = client.Request(request);
@@ -231,7 +223,6 @@ namespace Twilio.Rest.Autopilot.V1
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -323,7 +314,6 @@ namespace Twilio.Rest.Autopilot.V1
                 HttpMethod.Post,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -425,7 +415,6 @@ namespace Twilio.Rest.Autopilot.V1
                 HttpMethod.Delete,
                 Rest.Domain.Autopilot,
                 "/v1/Assistants/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Bulkexports/V1/Export/DayResource.cs
+++ b/src/Twilio/Rest/Bulkexports/V1/Export/DayResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Bulkexports.V1.Export
                 HttpMethod.Get,
                 Rest.Domain.Bulkexports,
                 "/v1/Exports/" + options.PathResourceType + "/Days/" + options.PathDay + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -98,7 +97,6 @@ namespace Twilio.Rest.Bulkexports.V1.Export
                 HttpMethod.Get,
                 Rest.Domain.Bulkexports,
                 "/v1/Exports/" + options.PathResourceType + "/Days",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -209,10 +207,7 @@ namespace Twilio.Rest.Bulkexports.V1.Export
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Bulkexports,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Bulkexports)
             );
 
             var response = client.Request(request);
@@ -229,10 +224,7 @@ namespace Twilio.Rest.Bulkexports.V1.Export
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Bulkexports,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Bulkexports)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Bulkexports/V1/Export/ExportCustomJobResource.cs
+++ b/src/Twilio/Rest/Bulkexports/V1/Export/ExportCustomJobResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Bulkexports.V1.Export
                 HttpMethod.Get,
                 Rest.Domain.Bulkexports,
                 "/v1/Exports/" + options.PathResourceType + "/Jobs",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -140,10 +139,7 @@ namespace Twilio.Rest.Bulkexports.V1.Export
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Bulkexports,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Bulkexports)
             );
 
             var response = client.Request(request);
@@ -161,10 +157,7 @@ namespace Twilio.Rest.Bulkexports.V1.Export
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Bulkexports,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Bulkexports)
             );
 
             var response = client.Request(request);
@@ -177,7 +170,6 @@ namespace Twilio.Rest.Bulkexports.V1.Export
                 HttpMethod.Post,
                 Rest.Domain.Bulkexports,
                 "/v1/Exports/" + options.PathResourceType + "/Jobs",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Bulkexports/V1/Export/JobResource.cs
+++ b/src/Twilio/Rest/Bulkexports/V1/Export/JobResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Bulkexports.V1.Export
                 HttpMethod.Get,
                 Rest.Domain.Bulkexports,
                 "/v1/Exports/Jobs/" + options.PathJobSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -95,7 +94,6 @@ namespace Twilio.Rest.Bulkexports.V1.Export
                 HttpMethod.Delete,
                 Rest.Domain.Bulkexports,
                 "/v1/Exports/Jobs/" + options.PathJobSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Bulkexports/V1/ExportConfigurationResource.cs
+++ b/src/Twilio/Rest/Bulkexports/V1/ExportConfigurationResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Bulkexports.V1
                 HttpMethod.Get,
                 Rest.Domain.Bulkexports,
                 "/v1/Exports/" + options.PathResourceType + "/Configuration",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Bulkexports.V1
                 HttpMethod.Post,
                 Rest.Domain.Bulkexports,
                 "/v1/Exports/" + options.PathResourceType + "/Configuration",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Bulkexports/V1/ExportResource.cs
+++ b/src/Twilio/Rest/Bulkexports/V1/ExportResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Bulkexports.V1
                 HttpMethod.Get,
                 Rest.Domain.Bulkexports,
                 "/v1/Exports/" + options.PathResourceType + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V1/CredentialResource.cs
+++ b/src/Twilio/Rest/Chat/V1/CredentialResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Chat.V1
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Credentials",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -140,10 +139,7 @@ namespace Twilio.Rest.Chat.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -160,10 +156,7 @@ namespace Twilio.Rest.Chat.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -176,7 +169,6 @@ namespace Twilio.Rest.Chat.V1
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Credentials",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -270,7 +262,6 @@ namespace Twilio.Rest.Chat.V1
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Credentials/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -337,7 +328,6 @@ namespace Twilio.Rest.Chat.V1
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Credentials/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -431,7 +421,6 @@ namespace Twilio.Rest.Chat.V1
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v1/Credentials/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V1/Service/Channel/InviteResource.cs
+++ b/src/Twilio/Rest/Chat/V1/Service/Channel/InviteResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -182,7 +180,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -293,10 +290,7 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -313,10 +307,7 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -329,7 +320,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V1/Service/Channel/MemberResource.cs
+++ b/src/Twilio/Rest/Chat/V1/Service/Channel/MemberResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -182,7 +180,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -293,10 +290,7 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -313,10 +307,7 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -329,7 +320,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -405,7 +395,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V1/Service/Channel/MessageResource.cs
+++ b/src/Twilio/Rest/Chat/V1/Service/Channel/MessageResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -116,7 +115,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -200,7 +198,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -311,10 +308,7 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -331,10 +325,7 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -347,7 +338,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -423,7 +413,6 @@ namespace Twilio.Rest.Chat.V1.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V1/Service/ChannelResource.cs
+++ b/src/Twilio/Rest/Chat/V1/Service/ChannelResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -180,7 +178,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -264,7 +261,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -371,10 +367,7 @@ namespace Twilio.Rest.Chat.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -391,10 +384,7 @@ namespace Twilio.Rest.Chat.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -407,7 +397,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V1/Service/RoleResource.cs
+++ b/src/Twilio/Rest/Chat/V1/Service/RoleResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -180,7 +178,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Roles",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -260,7 +257,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Roles",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -363,10 +359,7 @@ namespace Twilio.Rest.Chat.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -383,10 +376,7 @@ namespace Twilio.Rest.Chat.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -399,7 +389,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V1/Service/User/UserChannelResource.cs
+++ b/src/Twilio/Rest/Chat/V1/Service/User/UserChannelResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Chat.V1.Service.User
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Channels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -148,10 +147,7 @@ namespace Twilio.Rest.Chat.V1.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -168,10 +164,7 @@ namespace Twilio.Rest.Chat.V1.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Chat/V1/Service/UserResource.cs
+++ b/src/Twilio/Rest/Chat/V1/Service/UserResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -166,7 +164,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Users",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -250,7 +247,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Users",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -353,10 +349,7 @@ namespace Twilio.Rest.Chat.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -373,10 +366,7 @@ namespace Twilio.Rest.Chat.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -389,7 +379,6 @@ namespace Twilio.Rest.Chat.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V1/ServiceResource.cs
+++ b/src/Twilio/Rest/Chat/V1/ServiceResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Chat.V1
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -93,7 +92,6 @@ namespace Twilio.Rest.Chat.V1
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -159,7 +157,6 @@ namespace Twilio.Rest.Chat.V1
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -226,7 +223,6 @@ namespace Twilio.Rest.Chat.V1
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v1/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -325,10 +321,7 @@ namespace Twilio.Rest.Chat.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -345,10 +338,7 @@ namespace Twilio.Rest.Chat.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -361,7 +351,6 @@ namespace Twilio.Rest.Chat.V1
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/CredentialResource.cs
+++ b/src/Twilio/Rest/Chat/V2/CredentialResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Chat.V2
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Credentials",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -140,10 +139,7 @@ namespace Twilio.Rest.Chat.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -160,10 +156,7 @@ namespace Twilio.Rest.Chat.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -176,7 +169,6 @@ namespace Twilio.Rest.Chat.V2
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Credentials",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -270,7 +262,6 @@ namespace Twilio.Rest.Chat.V2
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Credentials/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -337,7 +328,6 @@ namespace Twilio.Rest.Chat.V2
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Credentials/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -431,7 +421,6 @@ namespace Twilio.Rest.Chat.V2
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Credentials/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/Service/BindingResource.cs
+++ b/src/Twilio/Rest/Chat/V2/Service/BindingResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Bindings",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -152,10 +151,7 @@ namespace Twilio.Rest.Chat.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -172,10 +168,7 @@ namespace Twilio.Rest.Chat.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -188,7 +181,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Bindings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -258,7 +250,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Bindings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/Service/Channel/InviteResource.cs
+++ b/src/Twilio/Rest/Chat/V2/Service/Channel/InviteResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -182,7 +180,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -293,10 +290,7 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -313,10 +307,7 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -329,7 +320,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/Service/Channel/MemberResource.cs
+++ b/src/Twilio/Rest/Chat/V2/Service/Channel/MemberResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -116,7 +115,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -218,7 +216,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -329,10 +326,7 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -349,10 +343,7 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -365,7 +356,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -441,7 +431,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/Service/Channel/MessageResource.cs
+++ b/src/Twilio/Rest/Chat/V2/Service/Channel/MessageResource.cs
@@ -53,7 +53,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -129,7 +128,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -229,7 +227,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -340,10 +337,7 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -360,10 +354,7 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -376,7 +367,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -452,7 +442,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/Service/Channel/WebhookResource.cs
+++ b/src/Twilio/Rest/Chat/V2/Service/Channel/WebhookResource.cs
@@ -54,7 +54,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Webhooks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -161,10 +160,7 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -181,10 +177,7 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -197,7 +190,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -273,7 +265,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Webhooks",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -375,7 +366,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -479,7 +469,6 @@ namespace Twilio.Rest.Chat.V2.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/Service/ChannelResource.cs
+++ b/src/Twilio/Rest/Chat/V2/Service/ChannelResource.cs
@@ -53,7 +53,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -123,7 +122,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -193,7 +191,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -289,7 +286,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -396,10 +392,7 @@ namespace Twilio.Rest.Chat.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -416,10 +409,7 @@ namespace Twilio.Rest.Chat.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -432,7 +422,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/Service/RoleResource.cs
+++ b/src/Twilio/Rest/Chat/V2/Service/RoleResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -180,7 +178,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Roles",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -260,7 +257,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Roles",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -363,10 +359,7 @@ namespace Twilio.Rest.Chat.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -383,10 +376,7 @@ namespace Twilio.Rest.Chat.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -399,7 +389,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/Service/User/UserBindingResource.cs
+++ b/src/Twilio/Rest/Chat/V2/Service/User/UserBindingResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Chat.V2.Service.User
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Bindings",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -152,10 +151,7 @@ namespace Twilio.Rest.Chat.V2.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -172,10 +168,7 @@ namespace Twilio.Rest.Chat.V2.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -188,7 +181,6 @@ namespace Twilio.Rest.Chat.V2.Service.User
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Bindings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -264,7 +256,6 @@ namespace Twilio.Rest.Chat.V2.Service.User
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Bindings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/Service/User/UserChannelResource.cs
+++ b/src/Twilio/Rest/Chat/V2/Service/User/UserChannelResource.cs
@@ -54,7 +54,6 @@ namespace Twilio.Rest.Chat.V2.Service.User
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Channels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -161,10 +160,7 @@ namespace Twilio.Rest.Chat.V2.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -181,10 +177,7 @@ namespace Twilio.Rest.Chat.V2.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -197,7 +190,6 @@ namespace Twilio.Rest.Chat.V2.Service.User
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Channels/" + options.PathChannelSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -273,7 +265,6 @@ namespace Twilio.Rest.Chat.V2.Service.User
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Channels/" + options.PathChannelSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -349,7 +340,6 @@ namespace Twilio.Rest.Chat.V2.Service.User
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Channels/" + options.PathChannelSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/Service/UserResource.cs
+++ b/src/Twilio/Rest/Chat/V2/Service/UserResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -180,7 +178,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -264,7 +261,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -367,10 +363,7 @@ namespace Twilio.Rest.Chat.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -387,10 +380,7 @@ namespace Twilio.Rest.Chat.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -403,7 +393,6 @@ namespace Twilio.Rest.Chat.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Chat/V2/ServiceResource.cs
+++ b/src/Twilio/Rest/Chat/V2/ServiceResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Chat.V2
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -93,7 +92,6 @@ namespace Twilio.Rest.Chat.V2
                 HttpMethod.Delete,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -159,7 +157,6 @@ namespace Twilio.Rest.Chat.V2
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -226,7 +223,6 @@ namespace Twilio.Rest.Chat.V2
                 HttpMethod.Get,
                 Rest.Domain.Chat,
                 "/v2/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -325,10 +321,7 @@ namespace Twilio.Rest.Chat.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -345,10 +338,7 @@ namespace Twilio.Rest.Chat.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Chat,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Chat)
             );
 
             var response = client.Request(request);
@@ -361,7 +351,6 @@ namespace Twilio.Rest.Chat.V2
                 HttpMethod.Post,
                 Rest.Domain.Chat,
                 "/v2/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Conversations/V1/Conversation/MessageResource.cs
+++ b/src/Twilio/Rest/Conversations/V1/Conversation/MessageResource.cs
@@ -42,7 +42,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Post,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Messages",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -134,7 +133,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Post,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -226,7 +224,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Delete,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -296,7 +293,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Get,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -366,7 +362,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Get,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Messages",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -469,10 +464,7 @@ namespace Twilio.Rest.Conversations.V1.Conversation
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Conversations,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Conversations)
             );
 
             var response = client.Request(request);
@@ -489,10 +481,7 @@ namespace Twilio.Rest.Conversations.V1.Conversation
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Conversations,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Conversations)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Conversations/V1/Conversation/ParticipantResource.cs
+++ b/src/Twilio/Rest/Conversations/V1/Conversation/ParticipantResource.cs
@@ -42,7 +42,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Post,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Participants",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -142,7 +141,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Post,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Participants/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -226,7 +224,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Delete,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Participants/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -296,7 +293,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Get,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Participants/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -366,7 +362,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Get,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Participants",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -469,10 +464,7 @@ namespace Twilio.Rest.Conversations.V1.Conversation
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Conversations,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Conversations)
             );
 
             var response = client.Request(request);
@@ -489,10 +481,7 @@ namespace Twilio.Rest.Conversations.V1.Conversation
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Conversations,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Conversations)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Conversations/V1/Conversation/WebhookResource.cs
+++ b/src/Twilio/Rest/Conversations/V1/Conversation/WebhookResource.cs
@@ -56,7 +56,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Get,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Webhooks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -159,10 +158,7 @@ namespace Twilio.Rest.Conversations.V1.Conversation
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Conversations,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Conversations)
             );
 
             var response = client.Request(request);
@@ -179,10 +175,7 @@ namespace Twilio.Rest.Conversations.V1.Conversation
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Conversations,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Conversations)
             );
 
             var response = client.Request(request);
@@ -195,7 +188,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Get,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -265,7 +257,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Post,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Webhooks",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -363,7 +354,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Post,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -455,7 +445,6 @@ namespace Twilio.Rest.Conversations.V1.Conversation
                 HttpMethod.Delete,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathConversationSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Conversations/V1/ConversationResource.cs
+++ b/src/Twilio/Rest/Conversations/V1/ConversationResource.cs
@@ -56,7 +56,6 @@ namespace Twilio.Rest.Conversations.V1
                 HttpMethod.Post,
                 Rest.Domain.Conversations,
                 "/v1/Conversations",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -144,7 +143,6 @@ namespace Twilio.Rest.Conversations.V1
                 HttpMethod.Post,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -236,7 +234,6 @@ namespace Twilio.Rest.Conversations.V1
                 HttpMethod.Delete,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -302,7 +299,6 @@ namespace Twilio.Rest.Conversations.V1
                 HttpMethod.Get,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -369,7 +365,6 @@ namespace Twilio.Rest.Conversations.V1
                 HttpMethod.Get,
                 Rest.Domain.Conversations,
                 "/v1/Conversations",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -469,10 +464,7 @@ namespace Twilio.Rest.Conversations.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Conversations,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Conversations)
             );
 
             var response = client.Request(request);
@@ -489,10 +481,7 @@ namespace Twilio.Rest.Conversations.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Conversations,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Conversations)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Conversations/V1/WebhookResource.cs
+++ b/src/Twilio/Rest/Conversations/V1/WebhookResource.cs
@@ -55,7 +55,6 @@ namespace Twilio.Rest.Conversations.V1
                 HttpMethod.Get,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/Webhooks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -119,7 +118,6 @@ namespace Twilio.Rest.Conversations.V1
                 HttpMethod.Post,
                 Rest.Domain.Conversations,
                 "/v1/Conversations/Webhooks",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Fax/V1/Fax/FaxMediaResource.cs
+++ b/src/Twilio/Rest/Fax/V1/Fax/FaxMediaResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Fax.V1.Fax
                 HttpMethod.Get,
                 Rest.Domain.Fax,
                 "/v1/Faxes/" + options.PathFaxSid + "/Media/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -98,7 +97,6 @@ namespace Twilio.Rest.Fax.V1.Fax
                 HttpMethod.Get,
                 Rest.Domain.Fax,
                 "/v1/Faxes/" + options.PathFaxSid + "/Media",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -201,10 +199,7 @@ namespace Twilio.Rest.Fax.V1.Fax
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Fax,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Fax)
             );
 
             var response = client.Request(request);
@@ -221,10 +216,7 @@ namespace Twilio.Rest.Fax.V1.Fax
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Fax,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Fax)
             );
 
             var response = client.Request(request);
@@ -237,7 +229,6 @@ namespace Twilio.Rest.Fax.V1.Fax
                 HttpMethod.Delete,
                 Rest.Domain.Fax,
                 "/v1/Faxes/" + options.PathFaxSid + "/Media/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Fax/V1/FaxResource.cs
+++ b/src/Twilio/Rest/Fax/V1/FaxResource.cs
@@ -89,7 +89,6 @@ namespace Twilio.Rest.Fax.V1
                 HttpMethod.Get,
                 Rest.Domain.Fax,
                 "/v1/Faxes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -156,7 +155,6 @@ namespace Twilio.Rest.Fax.V1
                 HttpMethod.Get,
                 Rest.Domain.Fax,
                 "/v1/Faxes",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -271,10 +269,7 @@ namespace Twilio.Rest.Fax.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Fax,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Fax)
             );
 
             var response = client.Request(request);
@@ -291,10 +286,7 @@ namespace Twilio.Rest.Fax.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Fax,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Fax)
             );
 
             var response = client.Request(request);
@@ -307,7 +299,6 @@ namespace Twilio.Rest.Fax.V1
                 HttpMethod.Post,
                 Rest.Domain.Fax,
                 "/v1/Faxes",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -407,7 +398,6 @@ namespace Twilio.Rest.Fax.V1
                 HttpMethod.Post,
                 Rest.Domain.Fax,
                 "/v1/Faxes/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -479,7 +469,6 @@ namespace Twilio.Rest.Fax.V1
                 HttpMethod.Delete,
                 Rest.Domain.Fax,
                 "/v1/Faxes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/FlexApi/V1/ChannelResource.cs
+++ b/src/Twilio/Rest/FlexApi/V1/ChannelResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Get,
                 Rest.Domain.FlexApi,
                 "/v1/Channels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -125,10 +124,7 @@ namespace Twilio.Rest.FlexApi.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.FlexApi,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.FlexApi)
             );
 
             var response = client.Request(request);
@@ -145,10 +141,7 @@ namespace Twilio.Rest.FlexApi.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.FlexApi,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.FlexApi)
             );
 
             var response = client.Request(request);
@@ -161,7 +154,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Get,
                 Rest.Domain.FlexApi,
                 "/v1/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -228,7 +220,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Post,
                 Rest.Domain.FlexApi,
                 "/v1/Channels",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -332,7 +323,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Delete,
                 Rest.Domain.FlexApi,
                 "/v1/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/FlexApi/V1/ConfigurationResource.cs
+++ b/src/Twilio/Rest/FlexApi/V1/ConfigurationResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Get,
                 Rest.Domain.FlexApi,
                 "/v1/Configuration",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -108,7 +107,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Post,
                 Rest.Domain.FlexApi,
                 "/v1/Configuration",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -172,7 +170,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Post,
                 Rest.Domain.FlexApi,
                 "/v1/Configuration",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/FlexApi/V1/FlexFlowResource.cs
+++ b/src/Twilio/Rest/FlexApi/V1/FlexFlowResource.cs
@@ -58,7 +58,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Get,
                 Rest.Domain.FlexApi,
                 "/v1/FlexFlows",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -161,10 +160,7 @@ namespace Twilio.Rest.FlexApi.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.FlexApi,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.FlexApi)
             );
 
             var response = client.Request(request);
@@ -181,10 +177,7 @@ namespace Twilio.Rest.FlexApi.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.FlexApi,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.FlexApi)
             );
 
             var response = client.Request(request);
@@ -197,7 +190,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Get,
                 Rest.Domain.FlexApi,
                 "/v1/FlexFlows/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -264,7 +256,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Post,
                 Rest.Domain.FlexApi,
                 "/v1/FlexFlows",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -396,7 +387,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Post,
                 Rest.Domain.FlexApi,
                 "/v1/FlexFlows/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -532,7 +522,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Delete,
                 Rest.Domain.FlexApi,
                 "/v1/FlexFlows/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/FlexApi/V1/WebChannelResource.cs
+++ b/src/Twilio/Rest/FlexApi/V1/WebChannelResource.cs
@@ -39,7 +39,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Get,
                 Rest.Domain.FlexApi,
                 "/v1/WebChannels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -138,10 +137,7 @@ namespace Twilio.Rest.FlexApi.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.FlexApi,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.FlexApi)
             );
 
             var response = client.Request(request);
@@ -158,10 +154,7 @@ namespace Twilio.Rest.FlexApi.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.FlexApi,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.FlexApi)
             );
 
             var response = client.Request(request);
@@ -174,7 +167,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Get,
                 Rest.Domain.FlexApi,
                 "/v1/WebChannels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -241,7 +233,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Post,
                 Rest.Domain.FlexApi,
                 "/v1/WebChannels",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -329,7 +320,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Post,
                 Rest.Domain.FlexApi,
                 "/v1/WebChannels/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -405,7 +395,6 @@ namespace Twilio.Rest.FlexApi.V1
                 HttpMethod.Delete,
                 Rest.Domain.FlexApi,
                 "/v1/WebChannels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Insights/V1/Call/CallSummaryResource.cs
+++ b/src/Twilio/Rest/Insights/V1/Call/CallSummaryResource.cs
@@ -77,7 +77,6 @@ namespace Twilio.Rest.Insights.V1.Call
                 HttpMethod.Get,
                 Rest.Domain.Insights,
                 "/v1/Voice/" + options.PathCallSid + "/Summary",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Insights/V1/Call/EventResource.cs
+++ b/src/Twilio/Rest/Insights/V1/Call/EventResource.cs
@@ -62,7 +62,6 @@ namespace Twilio.Rest.Insights.V1.Call
                 HttpMethod.Get,
                 Rest.Domain.Insights,
                 "/v1/Voice/" + options.PathCallSid + "/Events",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -169,10 +168,7 @@ namespace Twilio.Rest.Insights.V1.Call
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Insights,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Insights)
             );
 
             var response = client.Request(request);
@@ -189,10 +185,7 @@ namespace Twilio.Rest.Insights.V1.Call
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Insights,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Insights)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Insights/V1/Call/MetricResource.cs
+++ b/src/Twilio/Rest/Insights/V1/Call/MetricResource.cs
@@ -61,7 +61,6 @@ namespace Twilio.Rest.Insights.V1.Call
                 HttpMethod.Get,
                 Rest.Domain.Insights,
                 "/v1/Voice/" + options.PathCallSid + "/Metrics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -172,10 +171,7 @@ namespace Twilio.Rest.Insights.V1.Call
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Insights,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Insights)
             );
 
             var response = client.Request(request);
@@ -192,10 +188,7 @@ namespace Twilio.Rest.Insights.V1.Call
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Insights,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Insights)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Insights/V1/CallResource.cs
+++ b/src/Twilio/Rest/Insights/V1/CallResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Insights.V1
                 HttpMethod.Get,
                 Rest.Domain.Insights,
                 "/v1/Voice/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V1/CredentialResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V1/CredentialResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.IpMessaging.V1
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Credentials",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -140,10 +139,7 @@ namespace Twilio.Rest.IpMessaging.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -160,10 +156,7 @@ namespace Twilio.Rest.IpMessaging.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -176,7 +169,6 @@ namespace Twilio.Rest.IpMessaging.V1
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Credentials",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -270,7 +262,6 @@ namespace Twilio.Rest.IpMessaging.V1
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Credentials/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -337,7 +328,6 @@ namespace Twilio.Rest.IpMessaging.V1
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Credentials/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -431,7 +421,6 @@ namespace Twilio.Rest.IpMessaging.V1
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v1/Credentials/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V1/Service/Channel/InviteResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V1/Service/Channel/InviteResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -182,7 +180,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -293,10 +290,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -313,10 +307,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -329,7 +320,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V1/Service/Channel/MemberResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V1/Service/Channel/MemberResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -182,7 +180,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -293,10 +290,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -313,10 +307,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -329,7 +320,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -405,7 +395,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V1/Service/Channel/MessageResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V1/Service/Channel/MessageResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -116,7 +115,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -200,7 +198,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -311,10 +308,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -331,10 +325,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -347,7 +338,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -423,7 +413,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V1/Service/ChannelResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V1/Service/ChannelResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -180,7 +178,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -264,7 +261,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -371,10 +367,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -391,10 +384,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -407,7 +397,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V1/Service/RoleResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V1/Service/RoleResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -180,7 +178,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Roles",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -260,7 +257,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Roles",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -363,10 +359,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -383,10 +376,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -399,7 +389,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V1/Service/User/UserChannelResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V1/Service/User/UserChannelResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service.User
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Channels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -148,10 +147,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -168,10 +164,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/IpMessaging/V1/Service/UserResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V1/Service/UserResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -166,7 +164,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Users",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -250,7 +247,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Users",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -353,10 +349,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -373,10 +366,7 @@ namespace Twilio.Rest.IpMessaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -389,7 +379,6 @@ namespace Twilio.Rest.IpMessaging.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V1/ServiceResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V1/ServiceResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.IpMessaging.V1
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -93,7 +92,6 @@ namespace Twilio.Rest.IpMessaging.V1
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -159,7 +157,6 @@ namespace Twilio.Rest.IpMessaging.V1
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -226,7 +223,6 @@ namespace Twilio.Rest.IpMessaging.V1
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v1/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -325,10 +321,7 @@ namespace Twilio.Rest.IpMessaging.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -345,10 +338,7 @@ namespace Twilio.Rest.IpMessaging.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -361,7 +351,6 @@ namespace Twilio.Rest.IpMessaging.V1
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/CredentialResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/CredentialResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.IpMessaging.V2
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Credentials",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -140,10 +139,7 @@ namespace Twilio.Rest.IpMessaging.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -160,10 +156,7 @@ namespace Twilio.Rest.IpMessaging.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -176,7 +169,6 @@ namespace Twilio.Rest.IpMessaging.V2
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Credentials",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -270,7 +262,6 @@ namespace Twilio.Rest.IpMessaging.V2
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Credentials/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -337,7 +328,6 @@ namespace Twilio.Rest.IpMessaging.V2
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Credentials/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -431,7 +421,6 @@ namespace Twilio.Rest.IpMessaging.V2
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Credentials/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/Service/BindingResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/Service/BindingResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Bindings",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -152,10 +151,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -172,10 +168,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -188,7 +181,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Bindings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -258,7 +250,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Bindings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/Service/Channel/InviteResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/Service/Channel/InviteResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -182,7 +180,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -293,10 +290,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -313,10 +307,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -329,7 +320,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Invites/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/Service/Channel/MemberResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/Service/Channel/MemberResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -116,7 +115,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -218,7 +216,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -329,10 +326,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -349,10 +343,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -365,7 +356,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -441,7 +431,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Members/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/Service/Channel/MessageResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/Service/Channel/MessageResource.cs
@@ -53,7 +53,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -129,7 +128,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -229,7 +227,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -340,10 +337,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -360,10 +354,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -376,7 +367,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -452,7 +442,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Messages/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/Service/Channel/WebhookResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/Service/Channel/WebhookResource.cs
@@ -54,7 +54,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Webhooks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -161,10 +160,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -181,10 +177,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -197,7 +190,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -273,7 +265,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Webhooks",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -375,7 +366,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -479,7 +469,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.Channel
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathChannelSid + "/Webhooks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/Service/ChannelResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/Service/ChannelResource.cs
@@ -53,7 +53,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -123,7 +122,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -193,7 +191,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -289,7 +286,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -396,10 +392,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -416,10 +409,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -432,7 +422,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/Service/RoleResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/Service/RoleResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -180,7 +178,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Roles",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -260,7 +257,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Roles",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -363,10 +359,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -383,10 +376,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -399,7 +389,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Roles/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/Service/User/UserBindingResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/Service/User/UserBindingResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Bindings",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -152,10 +151,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -172,10 +168,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -188,7 +181,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Bindings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -264,7 +256,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Bindings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/Service/User/UserChannelResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/Service/User/UserChannelResource.cs
@@ -54,7 +54,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Channels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -161,10 +160,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -181,10 +177,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -197,7 +190,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Channels/" + options.PathChannelSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -273,7 +265,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Channels/" + options.PathChannelSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -349,7 +340,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service.User
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathUserSid + "/Channels/" + options.PathChannelSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/Service/UserResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/Service/UserResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -180,7 +178,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -264,7 +261,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -367,10 +363,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -387,10 +380,7 @@ namespace Twilio.Rest.IpMessaging.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -403,7 +393,6 @@ namespace Twilio.Rest.IpMessaging.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathServiceSid + "/Users/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/IpMessaging/V2/ServiceResource.cs
+++ b/src/Twilio/Rest/IpMessaging/V2/ServiceResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.IpMessaging.V2
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -93,7 +92,6 @@ namespace Twilio.Rest.IpMessaging.V2
                 HttpMethod.Delete,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -159,7 +157,6 @@ namespace Twilio.Rest.IpMessaging.V2
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -226,7 +223,6 @@ namespace Twilio.Rest.IpMessaging.V2
                 HttpMethod.Get,
                 Rest.Domain.IpMessaging,
                 "/v2/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -325,10 +321,7 @@ namespace Twilio.Rest.IpMessaging.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -345,10 +338,7 @@ namespace Twilio.Rest.IpMessaging.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.IpMessaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.IpMessaging)
             );
 
             var response = client.Request(request);
@@ -361,7 +351,6 @@ namespace Twilio.Rest.IpMessaging.V2
                 HttpMethod.Post,
                 Rest.Domain.IpMessaging,
                 "/v2/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Lookups/V1/PhoneNumberResource.cs
+++ b/src/Twilio/Rest/Lookups/V1/PhoneNumberResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Lookups.V1
                 HttpMethod.Get,
                 Rest.Domain.Lookups,
                 "/v1/PhoneNumbers/" + options.PathPhoneNumber + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Messaging/V1/Service/AlphaSenderResource.cs
+++ b/src/Twilio/Rest/Messaging/V1/Service/AlphaSenderResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/AlphaSenders",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -98,7 +97,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/AlphaSenders",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -201,10 +199,7 @@ namespace Twilio.Rest.Messaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Messaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Messaging)
             );
 
             var response = client.Request(request);
@@ -221,10 +216,7 @@ namespace Twilio.Rest.Messaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Messaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Messaging)
             );
 
             var response = client.Request(request);
@@ -237,7 +229,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/AlphaSenders/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -307,7 +298,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/AlphaSenders/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Messaging/V1/Service/PhoneNumberResource.cs
+++ b/src/Twilio/Rest/Messaging/V1/Service/PhoneNumberResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/PhoneNumbers",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -100,7 +99,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/PhoneNumbers/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -170,7 +168,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/PhoneNumbers",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -273,10 +270,7 @@ namespace Twilio.Rest.Messaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Messaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Messaging)
             );
 
             var response = client.Request(request);
@@ -293,10 +287,7 @@ namespace Twilio.Rest.Messaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Messaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Messaging)
             );
 
             var response = client.Request(request);
@@ -309,7 +300,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/PhoneNumbers/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Messaging/V1/Service/ShortCodeResource.cs
+++ b/src/Twilio/Rest/Messaging/V1/Service/ShortCodeResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/ShortCodes",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -98,7 +97,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/ShortCodes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -168,7 +166,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/ShortCodes",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -271,10 +268,7 @@ namespace Twilio.Rest.Messaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Messaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Messaging)
             );
 
             var response = client.Request(request);
@@ -291,10 +285,7 @@ namespace Twilio.Rest.Messaging.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Messaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Messaging)
             );
 
             var response = client.Request(request);
@@ -307,7 +298,6 @@ namespace Twilio.Rest.Messaging.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathServiceSid + "/ShortCodes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Messaging/V1/ServiceResource.cs
+++ b/src/Twilio/Rest/Messaging/V1/ServiceResource.cs
@@ -43,7 +43,6 @@ namespace Twilio.Rest.Messaging.V1
                 HttpMethod.Post,
                 Rest.Domain.Messaging,
                 "/v1/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -171,7 +170,6 @@ namespace Twilio.Rest.Messaging.V1
                 HttpMethod.Post,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -303,7 +301,6 @@ namespace Twilio.Rest.Messaging.V1
                 HttpMethod.Get,
                 Rest.Domain.Messaging,
                 "/v1/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -402,10 +399,7 @@ namespace Twilio.Rest.Messaging.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Messaging,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Messaging)
             );
 
             var response = client.Request(request);
@@ -422,10 +416,7 @@ namespace Twilio.Rest.Messaging.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Messaging,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Messaging)
             );
 
             var response = client.Request(request);
@@ -438,7 +429,6 @@ namespace Twilio.Rest.Messaging.V1
                 HttpMethod.Get,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -505,7 +495,6 @@ namespace Twilio.Rest.Messaging.V1
                 HttpMethod.Delete,
                 Rest.Domain.Messaging,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Monitor/V1/AlertResource.cs
+++ b/src/Twilio/Rest/Monitor/V1/AlertResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Monitor.V1
                 HttpMethod.Get,
                 Rest.Domain.Monitor,
                 "/v1/Alerts/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -93,7 +92,6 @@ namespace Twilio.Rest.Monitor.V1
                 HttpMethod.Get,
                 Rest.Domain.Monitor,
                 "/v1/Alerts",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -204,10 +202,7 @@ namespace Twilio.Rest.Monitor.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Monitor,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Monitor)
             );
 
             var response = client.Request(request);
@@ -224,10 +219,7 @@ namespace Twilio.Rest.Monitor.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Monitor,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Monitor)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Monitor/V1/EventResource.cs
+++ b/src/Twilio/Rest/Monitor/V1/EventResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Monitor.V1
                 HttpMethod.Get,
                 Rest.Domain.Monitor,
                 "/v1/Events/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -93,7 +92,6 @@ namespace Twilio.Rest.Monitor.V1
                 HttpMethod.Get,
                 Rest.Domain.Monitor,
                 "/v1/Events",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -216,10 +214,7 @@ namespace Twilio.Rest.Monitor.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Monitor,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Monitor)
             );
 
             var response = client.Request(request);
@@ -236,10 +231,7 @@ namespace Twilio.Rest.Monitor.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Monitor,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Monitor)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Notify/V1/CredentialResource.cs
+++ b/src/Twilio/Rest/Notify/V1/CredentialResource.cs
@@ -43,7 +43,6 @@ namespace Twilio.Rest.Notify.V1
                 HttpMethod.Get,
                 Rest.Domain.Notify,
                 "/v1/Credentials",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -142,10 +141,7 @@ namespace Twilio.Rest.Notify.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Notify,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Notify)
             );
 
             var response = client.Request(request);
@@ -162,10 +158,7 @@ namespace Twilio.Rest.Notify.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Notify,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Notify)
             );
 
             var response = client.Request(request);
@@ -178,7 +171,6 @@ namespace Twilio.Rest.Notify.V1
                 HttpMethod.Post,
                 Rest.Domain.Notify,
                 "/v1/Credentials",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -274,7 +266,6 @@ namespace Twilio.Rest.Notify.V1
                 HttpMethod.Get,
                 Rest.Domain.Notify,
                 "/v1/Credentials/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -341,7 +332,6 @@ namespace Twilio.Rest.Notify.V1
                 HttpMethod.Post,
                 Rest.Domain.Notify,
                 "/v1/Credentials/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -437,7 +427,6 @@ namespace Twilio.Rest.Notify.V1
                 HttpMethod.Delete,
                 Rest.Domain.Notify,
                 "/v1/Credentials/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Notify/V1/Service/BindingResource.cs
+++ b/src/Twilio/Rest/Notify/V1/Service/BindingResource.cs
@@ -46,7 +46,6 @@ namespace Twilio.Rest.Notify.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Notify,
                 "/v1/Services/" + options.PathServiceSid + "/Bindings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -116,7 +115,6 @@ namespace Twilio.Rest.Notify.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Notify,
                 "/v1/Services/" + options.PathServiceSid + "/Bindings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -186,7 +184,6 @@ namespace Twilio.Rest.Notify.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Notify,
                 "/v1/Services/" + options.PathServiceSid + "/Bindings",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -284,7 +281,6 @@ namespace Twilio.Rest.Notify.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Notify,
                 "/v1/Services/" + options.PathServiceSid + "/Bindings",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -403,10 +399,7 @@ namespace Twilio.Rest.Notify.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Notify,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Notify)
             );
 
             var response = client.Request(request);
@@ -423,10 +416,7 @@ namespace Twilio.Rest.Notify.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Notify,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Notify)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Notify/V1/Service/NotificationResource.cs
+++ b/src/Twilio/Rest/Notify/V1/Service/NotificationResource.cs
@@ -42,7 +42,6 @@ namespace Twilio.Rest.Notify.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Notify,
                 "/v1/Services/" + options.PathServiceSid + "/Notifications",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Notify/V1/ServiceResource.cs
+++ b/src/Twilio/Rest/Notify/V1/ServiceResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Notify.V1
                 HttpMethod.Post,
                 Rest.Domain.Notify,
                 "/v1/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -146,7 +145,6 @@ namespace Twilio.Rest.Notify.V1
                 HttpMethod.Delete,
                 Rest.Domain.Notify,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -212,7 +210,6 @@ namespace Twilio.Rest.Notify.V1
                 HttpMethod.Get,
                 Rest.Domain.Notify,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -279,7 +276,6 @@ namespace Twilio.Rest.Notify.V1
                 HttpMethod.Get,
                 Rest.Domain.Notify,
                 "/v1/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -382,10 +378,7 @@ namespace Twilio.Rest.Notify.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Notify,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Notify)
             );
 
             var response = client.Request(request);
@@ -402,10 +395,7 @@ namespace Twilio.Rest.Notify.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Notify,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Notify)
             );
 
             var response = client.Request(request);
@@ -418,7 +408,6 @@ namespace Twilio.Rest.Notify.V1
                 HttpMethod.Post,
                 Rest.Domain.Notify,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/Bundle/ItemAssignmentResource.cs
+++ b/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/Bundle/ItemAssignmentResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance.Bundle
                 HttpMethod.Post,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/Bundles/" + options.PathBundleSid + "/ItemAssignments",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance.Bundle
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/Bundles/" + options.PathBundleSid + "/ItemAssignments",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -200,10 +198,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance.Bundle
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -220,10 +215,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance.Bundle
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -236,7 +228,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance.Bundle
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/Bundles/" + options.PathBundleSid + "/ItemAssignments/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -306,7 +297,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance.Bundle
                 HttpMethod.Delete,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/Bundles/" + options.PathBundleSid + "/ItemAssignments/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/BundleResource.cs
+++ b/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/BundleResource.cs
@@ -56,7 +56,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Post,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/Bundles",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -148,7 +147,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/Bundles",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -267,10 +265,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -287,10 +282,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -303,7 +295,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/Bundles/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -370,7 +361,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Post,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/Bundles/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/EndUserResource.cs
+++ b/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/EndUserResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Post,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/EndUsers",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -116,7 +115,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/EndUsers",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -215,10 +213,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -235,10 +230,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -251,7 +243,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/EndUsers/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -318,7 +309,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Post,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/EndUsers/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/EndUserTypeResource.cs
+++ b/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/EndUserTypeResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/EndUserTypes",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -125,10 +124,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -145,10 +141,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -161,7 +154,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/EndUserTypes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/RegulationResource.cs
+++ b/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/RegulationResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/Regulations",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -151,10 +150,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -171,10 +167,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -187,7 +180,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/Regulations/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/SupportingDocumentResource.cs
+++ b/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/SupportingDocumentResource.cs
@@ -43,7 +43,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Post,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/SupportingDocuments",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -120,7 +119,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/SupportingDocuments",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -221,10 +219,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -242,10 +237,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -258,7 +250,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/SupportingDocuments/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -326,7 +317,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Post,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/SupportingDocuments/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/SupportingDocumentTypeResource.cs
+++ b/src/Twilio/Rest/Numbers/V2/RegulatoryCompliance/SupportingDocumentTypeResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/SupportingDocumentTypes",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -127,10 +126,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -148,10 +144,7 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Numbers,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Numbers)
             );
 
             var response = client.Request(request);
@@ -164,7 +157,6 @@ namespace Twilio.Rest.Numbers.V2.RegulatoryCompliance
                 HttpMethod.Get,
                 Rest.Domain.Numbers,
                 "/v2/RegulatoryCompliance/SupportingDocumentTypes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/BulkExports/Export/DayResource.cs
+++ b/src/Twilio/Rest/Preview/BulkExports/Export/DayResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.BulkExports.Export
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/BulkExports/Exports/" + options.PathResourceType + "/Days/" + options.PathDay + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.BulkExports.Export
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/BulkExports/Exports/" + options.PathResourceType + "/Days",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -210,10 +208,7 @@ namespace Twilio.Rest.Preview.BulkExports.Export
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -230,10 +225,7 @@ namespace Twilio.Rest.Preview.BulkExports.Export
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Preview/BulkExports/Export/ExportCustomJobResource.cs
+++ b/src/Twilio/Rest/Preview/BulkExports/Export/ExportCustomJobResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.BulkExports.Export
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/BulkExports/Exports/" + options.PathResourceType + "/Jobs",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -141,10 +140,7 @@ namespace Twilio.Rest.Preview.BulkExports.Export
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -162,10 +158,7 @@ namespace Twilio.Rest.Preview.BulkExports.Export
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -178,7 +171,6 @@ namespace Twilio.Rest.Preview.BulkExports.Export
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/BulkExports/Exports/" + options.PathResourceType + "/Jobs",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/BulkExports/Export/JobResource.cs
+++ b/src/Twilio/Rest/Preview/BulkExports/Export/JobResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.BulkExports.Export
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/BulkExports/Exports/Jobs/" + options.PathJobSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Preview.BulkExports.Export
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/BulkExports/Exports/Jobs/" + options.PathJobSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/BulkExports/ExportConfigurationResource.cs
+++ b/src/Twilio/Rest/Preview/BulkExports/ExportConfigurationResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.BulkExports
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/BulkExports/Exports/" + options.PathResourceType + "/Configuration",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -97,7 +96,6 @@ namespace Twilio.Rest.Preview.BulkExports
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/BulkExports/Exports/" + options.PathResourceType + "/Configuration",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/BulkExports/ExportResource.cs
+++ b/src/Twilio/Rest/Preview/BulkExports/ExportResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.BulkExports
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/BulkExports/Exports/" + options.PathResourceType + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/DeployedDevices/Fleet/CertificateResource.cs
+++ b/src/Twilio/Rest/Preview/DeployedDevices/Fleet/CertificateResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Certificates/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Certificates/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -173,7 +171,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Certificates",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -253,7 +250,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Certificates",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -360,10 +356,7 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -380,10 +373,7 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -396,7 +386,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Certificates/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/DeployedDevices/Fleet/DeploymentResource.cs
+++ b/src/Twilio/Rest/Preview/DeployedDevices/Fleet/DeploymentResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Deployments/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Deployments/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -169,7 +167,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Deployments",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -249,7 +246,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Deployments",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -352,10 +348,7 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -372,10 +365,7 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -388,7 +378,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Deployments/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/DeployedDevices/Fleet/DeviceResource.cs
+++ b/src/Twilio/Rest/Preview/DeployedDevices/Fleet/DeviceResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Devices/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Devices/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -169,7 +167,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Devices",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -261,7 +258,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Devices",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -368,10 +364,7 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -388,10 +381,7 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -404,7 +394,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Devices/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/DeployedDevices/Fleet/KeyResource.cs
+++ b/src/Twilio/Rest/Preview/DeployedDevices/Fleet/KeyResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Keys/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Keys/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -173,7 +171,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Keys",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -249,7 +246,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Keys",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -356,10 +352,7 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -376,10 +369,7 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -392,7 +382,6 @@ namespace Twilio.Rest.Preview.DeployedDevices.Fleet
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathFleetSid + "/Keys/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/DeployedDevices/FleetResource.cs
+++ b/src/Twilio/Rest/Preview/DeployedDevices/FleetResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.DeployedDevices
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Preview.DeployedDevices
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -166,7 +164,6 @@ namespace Twilio.Rest.Preview.DeployedDevices
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -233,7 +230,6 @@ namespace Twilio.Rest.Preview.DeployedDevices
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -332,10 +328,7 @@ namespace Twilio.Rest.Preview.DeployedDevices
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -352,10 +345,7 @@ namespace Twilio.Rest.Preview.DeployedDevices
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -368,7 +358,6 @@ namespace Twilio.Rest.Preview.DeployedDevices
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/DeployedDevices/Fleets/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/HostedNumbers/AuthorizationDocument/DependentHostedNumberOrderResource.cs
+++ b/src/Twilio/Rest/Preview/HostedNumbers/AuthorizationDocument/DependentHostedNumberOrderResource.cs
@@ -63,7 +63,6 @@ namespace Twilio.Rest.Preview.HostedNumbers.AuthorizationDocument
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/HostedNumbers/AuthorizationDocuments/" + options.PathSigningDocumentSid + "/DependentHostedNumberOrders",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -188,10 +187,7 @@ namespace Twilio.Rest.Preview.HostedNumbers.AuthorizationDocument
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -209,10 +205,7 @@ namespace Twilio.Rest.Preview.HostedNumbers.AuthorizationDocument
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Preview/HostedNumbers/AuthorizationDocumentResource.cs
+++ b/src/Twilio/Rest/Preview/HostedNumbers/AuthorizationDocumentResource.cs
@@ -46,7 +46,6 @@ namespace Twilio.Rest.Preview.HostedNumbers
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/HostedNumbers/AuthorizationDocuments/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -114,7 +113,6 @@ namespace Twilio.Rest.Preview.HostedNumbers
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/HostedNumbers/AuthorizationDocuments/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -211,7 +209,6 @@ namespace Twilio.Rest.Preview.HostedNumbers
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/HostedNumbers/AuthorizationDocuments",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -320,10 +317,7 @@ namespace Twilio.Rest.Preview.HostedNumbers
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -341,10 +335,7 @@ namespace Twilio.Rest.Preview.HostedNumbers
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -357,7 +348,6 @@ namespace Twilio.Rest.Preview.HostedNumbers
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/HostedNumbers/AuthorizationDocuments",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/HostedNumbers/HostedNumberOrderResource.cs
+++ b/src/Twilio/Rest/Preview/HostedNumbers/HostedNumberOrderResource.cs
@@ -63,7 +63,6 @@ namespace Twilio.Rest.Preview.HostedNumbers
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/HostedNumbers/HostedNumberOrders/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -130,7 +129,6 @@ namespace Twilio.Rest.Preview.HostedNumbers
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/HostedNumbers/HostedNumberOrders/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -196,7 +194,6 @@ namespace Twilio.Rest.Preview.HostedNumbers
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/HostedNumbers/HostedNumberOrders/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -307,7 +304,6 @@ namespace Twilio.Rest.Preview.HostedNumbers
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/HostedNumbers/HostedNumberOrders",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -428,10 +424,7 @@ namespace Twilio.Rest.Preview.HostedNumbers
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -449,10 +442,7 @@ namespace Twilio.Rest.Preview.HostedNumbers
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -465,7 +455,6 @@ namespace Twilio.Rest.Preview.HostedNumbers
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/HostedNumbers/HostedNumberOrders",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Marketplace/AvailableAddOn/AvailableAddOnExtensionResource.cs
+++ b/src/Twilio/Rest/Preview/Marketplace/AvailableAddOn/AvailableAddOnExtensionResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Marketplace.AvailableAddOn
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/marketplace/AvailableAddOns/" + options.PathAvailableAddOnSid + "/Extensions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.Preview.Marketplace.AvailableAddOn
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/marketplace/AvailableAddOns/" + options.PathAvailableAddOnSid + "/Extensions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -207,10 +205,7 @@ namespace Twilio.Rest.Preview.Marketplace.AvailableAddOn
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -228,10 +223,7 @@ namespace Twilio.Rest.Preview.Marketplace.AvailableAddOn
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Preview/Marketplace/AvailableAddOnResource.cs
+++ b/src/Twilio/Rest/Preview/Marketplace/AvailableAddOnResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Marketplace
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/marketplace/AvailableAddOns/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Preview.Marketplace
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/marketplace/AvailableAddOns",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -196,10 +194,7 @@ namespace Twilio.Rest.Preview.Marketplace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -216,10 +211,7 @@ namespace Twilio.Rest.Preview.Marketplace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Preview/Marketplace/InstalledAddOn/InstalledAddOnExtensionResource.cs
+++ b/src/Twilio/Rest/Preview/Marketplace/InstalledAddOn/InstalledAddOnExtensionResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Marketplace.InstalledAddOn
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/marketplace/InstalledAddOns/" + options.PathInstalledAddOnSid + "/Extensions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.Preview.Marketplace.InstalledAddOn
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/marketplace/InstalledAddOns/" + options.PathInstalledAddOnSid + "/Extensions/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -179,7 +177,6 @@ namespace Twilio.Rest.Preview.Marketplace.InstalledAddOn
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/marketplace/InstalledAddOns/" + options.PathInstalledAddOnSid + "/Extensions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -284,10 +281,7 @@ namespace Twilio.Rest.Preview.Marketplace.InstalledAddOn
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -305,10 +299,7 @@ namespace Twilio.Rest.Preview.Marketplace.InstalledAddOn
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Preview/Marketplace/InstalledAddOnResource.cs
+++ b/src/Twilio/Rest/Preview/Marketplace/InstalledAddOnResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Marketplace
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/marketplace/InstalledAddOns",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -109,7 +108,6 @@ namespace Twilio.Rest.Preview.Marketplace
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/marketplace/InstalledAddOns/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -175,7 +173,6 @@ namespace Twilio.Rest.Preview.Marketplace
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/marketplace/InstalledAddOns/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -242,7 +239,6 @@ namespace Twilio.Rest.Preview.Marketplace
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/marketplace/InstalledAddOns/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -318,7 +314,6 @@ namespace Twilio.Rest.Preview.Marketplace
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/marketplace/InstalledAddOns",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -418,10 +413,7 @@ namespace Twilio.Rest.Preview.Marketplace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -438,10 +430,7 @@ namespace Twilio.Rest.Preview.Marketplace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Preview/Sync/Service/Document/DocumentPermissionResource.cs
+++ b/src/Twilio/Rest/Preview/Sync/Service/Document/DocumentPermissionResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Sync.Service.Document
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Documents/" + options.PathDocumentSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -106,7 +105,6 @@ namespace Twilio.Rest.Preview.Sync.Service.Document
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Documents/" + options.PathDocumentSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -182,7 +180,6 @@ namespace Twilio.Rest.Preview.Sync.Service.Document
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Documents/" + options.PathDocumentSid + "/Permissions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -291,10 +288,7 @@ namespace Twilio.Rest.Preview.Sync.Service.Document
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -312,10 +306,7 @@ namespace Twilio.Rest.Preview.Sync.Service.Document
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -328,7 +319,6 @@ namespace Twilio.Rest.Preview.Sync.Service.Document
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Documents/" + options.PathDocumentSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Sync/Service/DocumentResource.cs
+++ b/src/Twilio/Rest/Preview/Sync/Service/DocumentResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Documents/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Documents/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -169,7 +167,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Documents",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -245,7 +242,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Documents",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -348,10 +344,7 @@ namespace Twilio.Rest.Preview.Sync.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -368,10 +361,7 @@ namespace Twilio.Rest.Preview.Sync.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -384,7 +374,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Documents/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Sync/Service/SyncList/SyncListItemResource.cs
+++ b/src/Twilio/Rest/Preview/Sync/Service/SyncList/SyncListItemResource.cs
@@ -56,7 +56,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Items/" + options.PathIndex + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -132,7 +131,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Items/" + options.PathIndex + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -205,7 +203,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Items",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -281,7 +278,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Items",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -401,10 +397,7 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -421,10 +414,7 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -437,7 +427,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Items/" + options.PathIndex + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Sync/Service/SyncList/SyncListPermissionResource.cs
+++ b/src/Twilio/Rest/Preview/Sync/Service/SyncList/SyncListPermissionResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -106,7 +105,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -182,7 +180,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Permissions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -291,10 +288,7 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -312,10 +306,7 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -328,7 +319,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncList
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Sync/Service/SyncListResource.cs
+++ b/src/Twilio/Rest/Preview/Sync/Service/SyncListResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -169,7 +167,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -241,7 +238,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Lists",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -344,10 +340,7 @@ namespace Twilio.Rest.Preview.Sync.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -364,10 +357,7 @@ namespace Twilio.Rest.Preview.Sync.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Preview/Sync/Service/SyncMap/SyncMapItemResource.cs
+++ b/src/Twilio/Rest/Preview/Sync/Service/SyncMap/SyncMapItemResource.cs
@@ -56,7 +56,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Items/" + options.PathKey + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -132,7 +131,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Items/" + options.PathKey + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -205,7 +203,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Items",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -285,7 +282,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Items",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -404,10 +400,7 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -424,10 +417,7 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -440,7 +430,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Items/" + options.PathKey + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Sync/Service/SyncMap/SyncMapPermissionResource.cs
+++ b/src/Twilio/Rest/Preview/Sync/Service/SyncMap/SyncMapPermissionResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -105,7 +104,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -181,7 +179,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Permissions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -290,10 +287,7 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -311,10 +305,7 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -327,7 +318,6 @@ namespace Twilio.Rest.Preview.Sync.Service.SyncMap
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Sync/Service/SyncMapResource.cs
+++ b/src/Twilio/Rest/Preview/Sync/Service/SyncMapResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -169,7 +167,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -241,7 +238,6 @@ namespace Twilio.Rest.Preview.Sync.Service
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathServiceSid + "/Maps",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -344,10 +340,7 @@ namespace Twilio.Rest.Preview.Sync.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -364,10 +357,7 @@ namespace Twilio.Rest.Preview.Sync.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Preview/Sync/ServiceResource.cs
+++ b/src/Twilio/Rest/Preview/Sync/ServiceResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Sync
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Preview.Sync
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -162,7 +160,6 @@ namespace Twilio.Rest.Preview.Sync
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -242,7 +239,6 @@ namespace Twilio.Rest.Preview.Sync
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/Sync/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -341,10 +337,7 @@ namespace Twilio.Rest.Preview.Sync
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -361,10 +354,7 @@ namespace Twilio.Rest.Preview.Sync
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -377,7 +367,6 @@ namespace Twilio.Rest.Preview.Sync
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/Sync/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/TrustedComms/BrandedCallResource.cs
+++ b/src/Twilio/Rest/Preview/TrustedComms/BrandedCallResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.TrustedComms
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/TrustedComms/Business/BrandedCalls",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/TrustedComms/Business/Insights/ImpressionsRateResource.cs
+++ b/src/Twilio/Rest/Preview/TrustedComms/Business/Insights/ImpressionsRateResource.cs
@@ -46,7 +46,6 @@ namespace Twilio.Rest.Preview.TrustedComms.Business.Insights
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/TrustedComms/Businesses/" + options.PathBusinessSid + "/Insights/ImpressionsRate",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/TrustedComms/BusinessResource.cs
+++ b/src/Twilio/Rest/Preview/TrustedComms/BusinessResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.TrustedComms
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/TrustedComms/Businesses/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/TrustedComms/CpsResource.cs
+++ b/src/Twilio/Rest/Preview/TrustedComms/CpsResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.TrustedComms
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/TrustedComms/CPS",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/TrustedComms/CurrentCallResource.cs
+++ b/src/Twilio/Rest/Preview/TrustedComms/CurrentCallResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.TrustedComms
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/TrustedComms/CurrentCall",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/TrustedComms/PhoneCallResource.cs
+++ b/src/Twilio/Rest/Preview/TrustedComms/PhoneCallResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.TrustedComms
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/TrustedComms/Business/PhoneCalls",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/AssistantFallbackActionsResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/AssistantFallbackActionsResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FallbackActions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -97,7 +96,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FallbackActions",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/AssistantInitiationActionsResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/AssistantInitiationActionsResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/InitiationActions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -97,7 +96,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/InitiationActions",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/DialogueResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/DialogueResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Dialogues/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/FieldType/FieldValueResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/FieldType/FieldValueResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.FieldType
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathFieldTypeSid + "/FieldValues/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -105,7 +104,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.FieldType
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathFieldTypeSid + "/FieldValues",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -216,10 +214,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant.FieldType
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -236,10 +231,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant.FieldType
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -252,7 +244,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.FieldType
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathFieldTypeSid + "/FieldValues",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -340,7 +331,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.FieldType
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathFieldTypeSid + "/FieldValues/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/FieldTypeResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/FieldTypeResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FieldTypes",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -202,10 +200,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -222,10 +217,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -238,7 +230,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FieldTypes",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -318,7 +309,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -402,7 +392,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/FieldTypes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/ModelBuildResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/ModelBuildResource.cs
@@ -46,7 +46,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/ModelBuilds/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -116,7 +115,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/ModelBuilds",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -219,10 +217,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -239,10 +234,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -255,7 +247,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/ModelBuilds",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -333,7 +324,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/ModelBuilds/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -411,7 +401,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/ModelBuilds/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/QueryResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/QueryResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Queries/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Queries",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -216,10 +214,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -236,10 +231,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -252,7 +244,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Queries",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -346,7 +337,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Queries/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -428,7 +418,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Queries/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/StyleSheetResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/StyleSheetResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/StyleSheet",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/StyleSheet",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/Task/FieldResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/Task/FieldResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Fields/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -105,7 +104,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Fields",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -212,10 +210,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -232,10 +227,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -248,7 +240,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Fields",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -332,7 +323,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Fields/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/Task/SampleResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/Task/SampleResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Samples/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -105,7 +104,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Samples",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -216,10 +214,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -236,10 +231,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -252,7 +244,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Samples",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -340,7 +331,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Samples/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -432,7 +422,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Samples/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/Task/TaskActionsResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/Task/TaskActionsResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Actions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Actions",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/Task/TaskStatisticsResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/Task/TaskStatisticsResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant.Task
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathTaskSid + "/Statistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/Assistant/TaskResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/Assistant/TaskResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -202,10 +200,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -222,10 +217,7 @@ namespace Twilio.Rest.Preview.Understand.Assistant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -238,7 +230,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -328,7 +319,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -422,7 +412,6 @@ namespace Twilio.Rest.Preview.Understand.Assistant
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathAssistantSid + "/Tasks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Understand/AssistantResource.cs
+++ b/src/Twilio/Rest/Preview/Understand/AssistantResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Understand
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Preview.Understand
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/understand/Assistants",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -195,10 +193,7 @@ namespace Twilio.Rest.Preview.Understand
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -215,10 +210,7 @@ namespace Twilio.Rest.Preview.Understand
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -231,7 +223,6 @@ namespace Twilio.Rest.Preview.Understand
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -339,7 +330,6 @@ namespace Twilio.Rest.Preview.Understand
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -451,7 +441,6 @@ namespace Twilio.Rest.Preview.Understand
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/understand/Assistants/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Wireless/CommandResource.cs
+++ b/src/Twilio/Rest/Preview/Wireless/CommandResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/wireless/Commands/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/wireless/Commands",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -211,10 +209,7 @@ namespace Twilio.Rest.Preview.Wireless
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -231,10 +226,7 @@ namespace Twilio.Rest.Preview.Wireless
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -247,7 +239,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/wireless/Commands",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Wireless/RatePlanResource.cs
+++ b/src/Twilio/Rest/Preview/Wireless/RatePlanResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/wireless/RatePlans",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -128,10 +127,7 @@ namespace Twilio.Rest.Preview.Wireless
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -148,10 +144,7 @@ namespace Twilio.Rest.Preview.Wireless
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -164,7 +157,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/wireless/RatePlans/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -231,7 +223,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/wireless/RatePlans",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -335,7 +326,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/wireless/RatePlans/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -411,7 +401,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Delete,
                 Rest.Domain.Preview,
                 "/wireless/RatePlans/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Wireless/Sim/UsageResource.cs
+++ b/src/Twilio/Rest/Preview/Wireless/Sim/UsageResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Wireless.Sim
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/wireless/Sims/" + options.PathSimSid + "/Usage",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Preview/Wireless/SimResource.cs
+++ b/src/Twilio/Rest/Preview/Wireless/SimResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/wireless/Sims/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Get,
                 Rest.Domain.Preview,
                 "/wireless/Sims",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -215,10 +213,7 @@ namespace Twilio.Rest.Preview.Wireless
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -235,10 +230,7 @@ namespace Twilio.Rest.Preview.Wireless
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Preview,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Preview)
             );
 
             var response = client.Request(request);
@@ -251,7 +243,6 @@ namespace Twilio.Rest.Preview.Wireless
                 HttpMethod.Post,
                 Rest.Domain.Preview,
                 "/wireless/Sims/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Pricing/V1/Messaging/CountryResource.cs
+++ b/src/Twilio/Rest/Pricing/V1/Messaging/CountryResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Pricing.V1.Messaging
                 HttpMethod.Get,
                 Rest.Domain.Pricing,
                 "/v1/Messaging/Countries",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -126,10 +125,7 @@ namespace Twilio.Rest.Pricing.V1.Messaging
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Pricing,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Pricing)
             );
 
             var response = client.Request(request);
@@ -146,10 +142,7 @@ namespace Twilio.Rest.Pricing.V1.Messaging
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Pricing,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Pricing)
             );
 
             var response = client.Request(request);
@@ -162,7 +155,6 @@ namespace Twilio.Rest.Pricing.V1.Messaging
                 HttpMethod.Get,
                 Rest.Domain.Pricing,
                 "/v1/Messaging/Countries/" + options.PathIsoCountry + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Pricing/V1/PhoneNumber/CountryResource.cs
+++ b/src/Twilio/Rest/Pricing/V1/PhoneNumber/CountryResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Pricing.V1.PhoneNumber
                 HttpMethod.Get,
                 Rest.Domain.Pricing,
                 "/v1/PhoneNumbers/Countries",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -126,10 +125,7 @@ namespace Twilio.Rest.Pricing.V1.PhoneNumber
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Pricing,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Pricing)
             );
 
             var response = client.Request(request);
@@ -146,10 +142,7 @@ namespace Twilio.Rest.Pricing.V1.PhoneNumber
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Pricing,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Pricing)
             );
 
             var response = client.Request(request);
@@ -162,7 +155,6 @@ namespace Twilio.Rest.Pricing.V1.PhoneNumber
                 HttpMethod.Get,
                 Rest.Domain.Pricing,
                 "/v1/PhoneNumbers/Countries/" + options.PathIsoCountry + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Pricing/V1/Voice/CountryResource.cs
+++ b/src/Twilio/Rest/Pricing/V1/Voice/CountryResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Pricing.V1.Voice
                 HttpMethod.Get,
                 Rest.Domain.Pricing,
                 "/v1/Voice/Countries",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -126,10 +125,7 @@ namespace Twilio.Rest.Pricing.V1.Voice
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Pricing,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Pricing)
             );
 
             var response = client.Request(request);
@@ -146,10 +142,7 @@ namespace Twilio.Rest.Pricing.V1.Voice
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Pricing,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Pricing)
             );
 
             var response = client.Request(request);
@@ -162,7 +155,6 @@ namespace Twilio.Rest.Pricing.V1.Voice
                 HttpMethod.Get,
                 Rest.Domain.Pricing,
                 "/v1/Voice/Countries/" + options.PathIsoCountry + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Pricing/V1/Voice/NumberResource.cs
+++ b/src/Twilio/Rest/Pricing/V1/Voice/NumberResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Pricing.V1.Voice
                 HttpMethod.Get,
                 Rest.Domain.Pricing,
                 "/v1/Voice/Numbers/" + options.PathNumber + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Pricing/V2/Voice/CountryResource.cs
+++ b/src/Twilio/Rest/Pricing/V2/Voice/CountryResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Pricing.V2.Voice
                 HttpMethod.Get,
                 Rest.Domain.Pricing,
                 "/v2/Voice/Countries",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -126,10 +125,7 @@ namespace Twilio.Rest.Pricing.V2.Voice
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Pricing,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Pricing)
             );
 
             var response = client.Request(request);
@@ -146,10 +142,7 @@ namespace Twilio.Rest.Pricing.V2.Voice
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Pricing,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Pricing)
             );
 
             var response = client.Request(request);
@@ -162,7 +155,6 @@ namespace Twilio.Rest.Pricing.V2.Voice
                 HttpMethod.Get,
                 Rest.Domain.Pricing,
                 "/v2/Voice/Countries/" + options.PathIsoCountry + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Pricing/V2/Voice/NumberResource.cs
+++ b/src/Twilio/Rest/Pricing/V2/Voice/NumberResource.cs
@@ -27,7 +27,6 @@ namespace Twilio.Rest.Pricing.V2.Voice
                 HttpMethod.Get,
                 Rest.Domain.Pricing,
                 "/v2/Voice/Numbers/" + options.PathDestinationNumber + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Proxy/V1/Service/PhoneNumberResource.cs
+++ b/src/Twilio/Rest/Proxy/V1/Service/PhoneNumberResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/PhoneNumbers",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -109,7 +108,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/PhoneNumbers/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -179,7 +177,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/PhoneNumbers",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -286,10 +283,7 @@ namespace Twilio.Rest.Proxy.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -306,10 +300,7 @@ namespace Twilio.Rest.Proxy.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -322,7 +313,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/PhoneNumbers/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -392,7 +382,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/PhoneNumbers/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Proxy/V1/Service/Session/InteractionResource.cs
+++ b/src/Twilio/Rest/Proxy/V1/Service/Session/InteractionResource.cs
@@ -75,7 +75,6 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSessionSid + "/Interactions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -151,7 +150,6 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSessionSid + "/Interactions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -258,10 +256,7 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -278,10 +273,7 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -294,7 +286,6 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
                 HttpMethod.Delete,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSessionSid + "/Interactions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Proxy/V1/Service/Session/Participant/MessageInteractionResource.cs
+++ b/src/Twilio/Rest/Proxy/V1/Service/Session/Participant/MessageInteractionResource.cs
@@ -75,7 +75,6 @@ namespace Twilio.Rest.Proxy.V1.Service.Session.Participant
                 HttpMethod.Post,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSessionSid + "/Participants/" + options.PathParticipantSid + "/MessageInteractions",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -168,7 +167,6 @@ namespace Twilio.Rest.Proxy.V1.Service.Session.Participant
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSessionSid + "/Participants/" + options.PathParticipantSid + "/MessageInteractions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -249,7 +247,6 @@ namespace Twilio.Rest.Proxy.V1.Service.Session.Participant
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSessionSid + "/Participants/" + options.PathParticipantSid + "/MessageInteractions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -362,10 +359,7 @@ namespace Twilio.Rest.Proxy.V1.Service.Session.Participant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -383,10 +377,7 @@ namespace Twilio.Rest.Proxy.V1.Service.Session.Participant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Proxy/V1/Service/Session/ParticipantResource.cs
+++ b/src/Twilio/Rest/Proxy/V1/Service/Session/ParticipantResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSessionSid + "/Participants/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -104,7 +103,6 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSessionSid + "/Participants",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -211,10 +209,7 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -231,10 +226,7 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -247,7 +239,6 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
                 HttpMethod.Post,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSessionSid + "/Participants",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -335,7 +326,6 @@ namespace Twilio.Rest.Proxy.V1.Service.Session
                 HttpMethod.Delete,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSessionSid + "/Participants/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Proxy/V1/Service/SessionResource.cs
+++ b/src/Twilio/Rest/Proxy/V1/Service/SessionResource.cs
@@ -59,7 +59,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -129,7 +128,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -232,10 +230,7 @@ namespace Twilio.Rest.Proxy.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -252,10 +247,7 @@ namespace Twilio.Rest.Proxy.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -268,7 +260,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -360,7 +351,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -430,7 +420,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/Sessions/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Proxy/V1/Service/ShortCodeResource.cs
+++ b/src/Twilio/Rest/Proxy/V1/Service/ShortCodeResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/ShortCodes",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -99,7 +98,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/ShortCodes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -169,7 +167,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/ShortCodes",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -276,10 +273,7 @@ namespace Twilio.Rest.Proxy.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -296,10 +290,7 @@ namespace Twilio.Rest.Proxy.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -312,7 +303,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/ShortCodes/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -382,7 +372,6 @@ namespace Twilio.Rest.Proxy.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathServiceSid + "/ShortCodes/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Proxy/V1/ServiceResource.cs
+++ b/src/Twilio/Rest/Proxy/V1/ServiceResource.cs
@@ -57,7 +57,6 @@ namespace Twilio.Rest.Proxy.V1
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -124,7 +123,6 @@ namespace Twilio.Rest.Proxy.V1
                 HttpMethod.Get,
                 Rest.Domain.Proxy,
                 "/v1/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -223,10 +221,7 @@ namespace Twilio.Rest.Proxy.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -243,10 +238,7 @@ namespace Twilio.Rest.Proxy.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Proxy,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Proxy)
             );
 
             var response = client.Request(request);
@@ -259,7 +251,6 @@ namespace Twilio.Rest.Proxy.V1
                 HttpMethod.Post,
                 Rest.Domain.Proxy,
                 "/v1/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -357,7 +348,6 @@ namespace Twilio.Rest.Proxy.V1
                 HttpMethod.Delete,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -423,7 +413,6 @@ namespace Twilio.Rest.Proxy.V1
                 HttpMethod.Post,
                 Rest.Domain.Proxy,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/Service/Asset/AssetVersionResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/Service/Asset/AssetVersionResource.cs
@@ -44,7 +44,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Asset
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Assets/" + options.PathAssetSid + "/Versions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -154,10 +153,7 @@ namespace Twilio.Rest.Serverless.V1.Service.Asset
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -174,10 +170,7 @@ namespace Twilio.Rest.Serverless.V1.Service.Asset
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -190,7 +183,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Asset
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Assets/" + options.PathAssetSid + "/Versions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/Service/AssetResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/Service/AssetResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Assets",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -132,10 +131,7 @@ namespace Twilio.Rest.Serverless.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -152,10 +148,7 @@ namespace Twilio.Rest.Serverless.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -168,7 +161,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Assets/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -238,7 +230,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Assets/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -308,7 +299,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Assets",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -378,7 +368,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Assets/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/Service/BuildResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/Service/BuildResource.cs
@@ -44,7 +44,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Builds",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -147,10 +146,7 @@ namespace Twilio.Rest.Serverless.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -167,10 +163,7 @@ namespace Twilio.Rest.Serverless.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -183,7 +176,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Builds/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -253,7 +245,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Builds/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -323,7 +314,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Builds",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/Service/Environment/DeploymentResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/Service/Environment/DeploymentResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathEnvironmentSid + "/Deployments",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -136,10 +135,7 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -156,10 +152,7 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -172,7 +165,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathEnvironmentSid + "/Deployments/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -248,7 +240,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathEnvironmentSid + "/Deployments",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/Service/Environment/LogResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/Service/Environment/LogResource.cs
@@ -44,7 +44,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathEnvironmentSid + "/Logs",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -163,10 +162,7 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -183,10 +179,7 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -199,7 +192,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathEnvironmentSid + "/Logs/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/Service/Environment/VariableResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/Service/Environment/VariableResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathEnvironmentSid + "/Variables",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -136,10 +135,7 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -156,10 +152,7 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -172,7 +165,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathEnvironmentSid + "/Variables/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -248,7 +240,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathEnvironmentSid + "/Variables",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -328,7 +319,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathEnvironmentSid + "/Variables/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -412,7 +402,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Environment
                 HttpMethod.Delete,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathEnvironmentSid + "/Variables/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/Service/EnvironmentResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/Service/EnvironmentResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -132,10 +131,7 @@ namespace Twilio.Rest.Serverless.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -152,10 +148,7 @@ namespace Twilio.Rest.Serverless.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -168,7 +161,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -238,7 +230,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -314,7 +305,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Environments/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/Service/Function/FunctionVersion/FunctionVersionContentResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/Service/Function/FunctionVersion/FunctionVersionContentResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Function.FunctionVersion
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Functions/" + options.PathFunctionSid + "/Versions/" + options.PathSid + "/Content",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/Service/Function/FunctionVersionResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/Service/Function/FunctionVersionResource.cs
@@ -44,7 +44,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Function
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Functions/" + options.PathFunctionSid + "/Versions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -154,10 +153,7 @@ namespace Twilio.Rest.Serverless.V1.Service.Function
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -175,10 +171,7 @@ namespace Twilio.Rest.Serverless.V1.Service.Function
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -191,7 +184,6 @@ namespace Twilio.Rest.Serverless.V1.Service.Function
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Functions/" + options.PathFunctionSid + "/Versions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/Service/FunctionResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/Service/FunctionResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Functions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -132,10 +131,7 @@ namespace Twilio.Rest.Serverless.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -152,10 +148,7 @@ namespace Twilio.Rest.Serverless.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -168,7 +161,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Functions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -238,7 +230,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Functions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -308,7 +299,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Functions",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -378,7 +368,6 @@ namespace Twilio.Rest.Serverless.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathServiceSid + "/Functions/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Serverless/V1/ServiceResource.cs
+++ b/src/Twilio/Rest/Serverless/V1/ServiceResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Serverless.V1
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -128,10 +127,7 @@ namespace Twilio.Rest.Serverless.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -148,10 +144,7 @@ namespace Twilio.Rest.Serverless.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Serverless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Serverless)
             );
 
             var response = client.Request(request);
@@ -164,7 +157,6 @@ namespace Twilio.Rest.Serverless.V1
                 HttpMethod.Get,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -231,7 +223,6 @@ namespace Twilio.Rest.Serverless.V1
                 HttpMethod.Delete,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -297,7 +288,6 @@ namespace Twilio.Rest.Serverless.V1
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -377,7 +367,6 @@ namespace Twilio.Rest.Serverless.V1
                 HttpMethod.Post,
                 Rest.Domain.Serverless,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V1/Flow/Engagement/EngagementContextResource.cs
+++ b/src/Twilio/Rest/Studio/V1/Flow/Engagement/EngagementContextResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Studio.V1.Flow.Engagement
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Engagements/" + options.PathEngagementSid + "/Context",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V1/Flow/Engagement/Step/StepContextResource.cs
+++ b/src/Twilio/Rest/Studio/V1/Flow/Engagement/Step/StepContextResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Studio.V1.Flow.Engagement.Step
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Engagements/" + options.PathEngagementSid + "/Steps/" + options.PathStepSid + "/Context",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V1/Flow/Engagement/StepResource.cs
+++ b/src/Twilio/Rest/Studio/V1/Flow/Engagement/StepResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Studio.V1.Flow.Engagement
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Engagements/" + options.PathEngagementSid + "/Steps",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -133,10 +132,7 @@ namespace Twilio.Rest.Studio.V1.Flow.Engagement
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -153,10 +149,7 @@ namespace Twilio.Rest.Studio.V1.Flow.Engagement
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -169,7 +162,6 @@ namespace Twilio.Rest.Studio.V1.Flow.Engagement
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Engagements/" + options.PathEngagementSid + "/Steps/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V1/Flow/EngagementResource.cs
+++ b/src/Twilio/Rest/Studio/V1/Flow/EngagementResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Studio.V1.Flow
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Engagements",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -143,10 +142,7 @@ namespace Twilio.Rest.Studio.V1.Flow
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -163,10 +159,7 @@ namespace Twilio.Rest.Studio.V1.Flow
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -179,7 +172,6 @@ namespace Twilio.Rest.Studio.V1.Flow
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Engagements/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -249,7 +241,6 @@ namespace Twilio.Rest.Studio.V1.Flow
                 HttpMethod.Post,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Engagements",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -333,7 +324,6 @@ namespace Twilio.Rest.Studio.V1.Flow
                 HttpMethod.Delete,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Engagements/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V1/Flow/Execution/ExecutionContextResource.cs
+++ b/src/Twilio/Rest/Studio/V1/Flow/Execution/ExecutionContextResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Studio.V1.Flow.Execution
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Executions/" + options.PathExecutionSid + "/Context",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V1/Flow/Execution/ExecutionStep/ExecutionStepContextResource.cs
+++ b/src/Twilio/Rest/Studio/V1/Flow/Execution/ExecutionStep/ExecutionStepContextResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Studio.V1.Flow.Execution.ExecutionStep
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Executions/" + options.PathExecutionSid + "/Steps/" + options.PathStepSid + "/Context",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V1/Flow/Execution/ExecutionStepResource.cs
+++ b/src/Twilio/Rest/Studio/V1/Flow/Execution/ExecutionStepResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Studio.V1.Flow.Execution
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Executions/" + options.PathExecutionSid + "/Steps",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -134,10 +133,7 @@ namespace Twilio.Rest.Studio.V1.Flow.Execution
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -154,10 +150,7 @@ namespace Twilio.Rest.Studio.V1.Flow.Execution
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -170,7 +163,6 @@ namespace Twilio.Rest.Studio.V1.Flow.Execution
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Executions/" + options.PathExecutionSid + "/Steps/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V1/Flow/ExecutionResource.cs
+++ b/src/Twilio/Rest/Studio/V1/Flow/ExecutionResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Studio.V1.Flow
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Executions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -151,10 +150,7 @@ namespace Twilio.Rest.Studio.V1.Flow
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -171,10 +167,7 @@ namespace Twilio.Rest.Studio.V1.Flow
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -187,7 +180,6 @@ namespace Twilio.Rest.Studio.V1.Flow
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Executions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -257,7 +249,6 @@ namespace Twilio.Rest.Studio.V1.Flow
                 HttpMethod.Post,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Executions",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -339,7 +330,6 @@ namespace Twilio.Rest.Studio.V1.Flow
                 HttpMethod.Delete,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Executions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -409,7 +399,6 @@ namespace Twilio.Rest.Studio.V1.Flow
                 HttpMethod.Post,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathFlowSid + "/Executions/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V1/FlowResource.cs
+++ b/src/Twilio/Rest/Studio/V1/FlowResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Studio.V1
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -139,10 +138,7 @@ namespace Twilio.Rest.Studio.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -159,10 +155,7 @@ namespace Twilio.Rest.Studio.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -175,7 +168,6 @@ namespace Twilio.Rest.Studio.V1
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -242,7 +234,6 @@ namespace Twilio.Rest.Studio.V1
                 HttpMethod.Delete,
                 Rest.Domain.Studio,
                 "/v1/Flows/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V2/Flow/Execution/ExecutionContextResource.cs
+++ b/src/Twilio/Rest/Studio/V2/Flow/Execution/ExecutionContextResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Studio.V2.Flow.Execution
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathFlowSid + "/Executions/" + options.PathExecutionSid + "/Context",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V2/Flow/Execution/ExecutionStep/ExecutionStepContextResource.cs
+++ b/src/Twilio/Rest/Studio/V2/Flow/Execution/ExecutionStep/ExecutionStepContextResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Studio.V2.Flow.Execution.ExecutionStep
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathFlowSid + "/Executions/" + options.PathExecutionSid + "/Steps/" + options.PathStepSid + "/Context",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V2/Flow/Execution/ExecutionStepResource.cs
+++ b/src/Twilio/Rest/Studio/V2/Flow/Execution/ExecutionStepResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Studio.V2.Flow.Execution
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathFlowSid + "/Executions/" + options.PathExecutionSid + "/Steps",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -136,10 +135,7 @@ namespace Twilio.Rest.Studio.V2.Flow.Execution
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -156,10 +152,7 @@ namespace Twilio.Rest.Studio.V2.Flow.Execution
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -172,7 +165,6 @@ namespace Twilio.Rest.Studio.V2.Flow.Execution
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathFlowSid + "/Executions/" + options.PathExecutionSid + "/Steps/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V2/Flow/ExecutionResource.cs
+++ b/src/Twilio/Rest/Studio/V2/Flow/ExecutionResource.cs
@@ -42,7 +42,6 @@ namespace Twilio.Rest.Studio.V2.Flow
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathFlowSid + "/Executions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -153,10 +152,7 @@ namespace Twilio.Rest.Studio.V2.Flow
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -173,10 +169,7 @@ namespace Twilio.Rest.Studio.V2.Flow
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -189,7 +182,6 @@ namespace Twilio.Rest.Studio.V2.Flow
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathFlowSid + "/Executions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -259,7 +251,6 @@ namespace Twilio.Rest.Studio.V2.Flow
                 HttpMethod.Post,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathFlowSid + "/Executions",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -341,7 +332,6 @@ namespace Twilio.Rest.Studio.V2.Flow
                 HttpMethod.Delete,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathFlowSid + "/Executions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -411,7 +401,6 @@ namespace Twilio.Rest.Studio.V2.Flow
                 HttpMethod.Post,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathFlowSid + "/Executions/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V2/Flow/FlowRevisionResource.cs
+++ b/src/Twilio/Rest/Studio/V2/Flow/FlowRevisionResource.cs
@@ -42,7 +42,6 @@ namespace Twilio.Rest.Studio.V2.Flow
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathSid + "/Revisions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -146,10 +145,7 @@ namespace Twilio.Rest.Studio.V2.Flow
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -166,10 +162,7 @@ namespace Twilio.Rest.Studio.V2.Flow
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -182,7 +175,6 @@ namespace Twilio.Rest.Studio.V2.Flow
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathSid + "/Revisions/" + options.PathRevision + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V2/Flow/FlowTestUserResource.cs
+++ b/src/Twilio/Rest/Studio/V2/Flow/FlowTestUserResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Studio.V2.Flow
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathSid + "/TestUsers",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -95,7 +94,6 @@ namespace Twilio.Rest.Studio.V2.Flow
                 HttpMethod.Post,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathSid + "/TestUsers",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V2/FlowResource.cs
+++ b/src/Twilio/Rest/Studio/V2/FlowResource.cs
@@ -42,7 +42,6 @@ namespace Twilio.Rest.Studio.V2
                 HttpMethod.Post,
                 Rest.Domain.Studio,
                 "/v2/Flows",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -122,7 +121,6 @@ namespace Twilio.Rest.Studio.V2
                 HttpMethod.Post,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -206,7 +204,6 @@ namespace Twilio.Rest.Studio.V2
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -305,10 +302,7 @@ namespace Twilio.Rest.Studio.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -325,10 +319,7 @@ namespace Twilio.Rest.Studio.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Studio,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Studio)
             );
 
             var response = client.Request(request);
@@ -341,7 +332,6 @@ namespace Twilio.Rest.Studio.V2
                 HttpMethod.Get,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -408,7 +398,6 @@ namespace Twilio.Rest.Studio.V2
                 HttpMethod.Delete,
                 Rest.Domain.Studio,
                 "/v2/Flows/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Studio/V2/FlowValidateResource.cs
+++ b/src/Twilio/Rest/Studio/V2/FlowValidateResource.cs
@@ -42,7 +42,6 @@ namespace Twilio.Rest.Studio.V2
                 HttpMethod.Post,
                 Rest.Domain.Studio,
                 "/v2/Flows/Validate",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Supersim/V1/CommandResource.cs
+++ b/src/Twilio/Rest/Supersim/V1/CommandResource.cs
@@ -59,7 +59,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Post,
                 Rest.Domain.Supersim,
                 "/v1/Commands",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -139,7 +138,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Get,
                 Rest.Domain.Supersim,
                 "/v1/Commands/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -206,7 +204,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Get,
                 Rest.Domain.Supersim,
                 "/v1/Commands",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -317,10 +314,7 @@ namespace Twilio.Rest.Supersim.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Supersim,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Supersim)
             );
 
             var response = client.Request(request);
@@ -337,10 +331,7 @@ namespace Twilio.Rest.Supersim.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Supersim,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Supersim)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Supersim/V1/FleetResource.cs
+++ b/src/Twilio/Rest/Supersim/V1/FleetResource.cs
@@ -42,7 +42,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Post,
                 Rest.Domain.Supersim,
                 "/v1/Fleets",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -132,7 +131,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Get,
                 Rest.Domain.Supersim,
                 "/v1/Fleets/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -199,7 +197,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Get,
                 Rest.Domain.Supersim,
                 "/v1/Fleets",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -298,10 +295,7 @@ namespace Twilio.Rest.Supersim.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Supersim,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Supersim)
             );
 
             var response = client.Request(request);
@@ -318,10 +312,7 @@ namespace Twilio.Rest.Supersim.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Supersim,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Supersim)
             );
 
             var response = client.Request(request);
@@ -334,7 +325,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Post,
                 Rest.Domain.Supersim,
                 "/v1/Fleets/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Supersim/V1/SimResource.cs
+++ b/src/Twilio/Rest/Supersim/V1/SimResource.cs
@@ -59,7 +59,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Get,
                 Rest.Domain.Supersim,
                 "/v1/Sims/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -126,7 +125,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Post,
                 Rest.Domain.Supersim,
                 "/v1/Sims/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -206,7 +204,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Get,
                 Rest.Domain.Supersim,
                 "/v1/Sims",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -317,10 +314,7 @@ namespace Twilio.Rest.Supersim.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Supersim,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Supersim)
             );
 
             var response = client.Request(request);
@@ -337,10 +331,7 @@ namespace Twilio.Rest.Supersim.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Supersim,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Supersim)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Supersim/V1/UsageRecordResource.cs
+++ b/src/Twilio/Rest/Supersim/V1/UsageRecordResource.cs
@@ -81,7 +81,6 @@ namespace Twilio.Rest.Supersim.V1
                 HttpMethod.Get,
                 Rest.Domain.Supersim,
                 "/v1/UsageRecords",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -200,10 +199,7 @@ namespace Twilio.Rest.Supersim.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Supersim,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Supersim)
             );
 
             var response = client.Request(request);
@@ -220,10 +216,7 @@ namespace Twilio.Rest.Supersim.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Supersim,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Supersim)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Sync/V1/Service/Document/DocumentPermissionResource.cs
+++ b/src/Twilio/Rest/Sync/V1/Service/Document/DocumentPermissionResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Sync.V1.Service.Document
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Documents/" + options.PathDocumentSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -107,7 +106,6 @@ namespace Twilio.Rest.Sync.V1.Service.Document
                 HttpMethod.Delete,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Documents/" + options.PathDocumentSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -185,7 +183,6 @@ namespace Twilio.Rest.Sync.V1.Service.Document
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Documents/" + options.PathDocumentSid + "/Permissions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -294,10 +291,7 @@ namespace Twilio.Rest.Sync.V1.Service.Document
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -315,10 +309,7 @@ namespace Twilio.Rest.Sync.V1.Service.Document
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -331,7 +322,6 @@ namespace Twilio.Rest.Sync.V1.Service.Document
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Documents/" + options.PathDocumentSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Sync/V1/Service/DocumentResource.cs
+++ b/src/Twilio/Rest/Sync/V1/Service/DocumentResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Documents/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -98,7 +97,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Documents/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -168,7 +166,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Documents",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -250,7 +247,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Documents",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -353,10 +349,7 @@ namespace Twilio.Rest.Sync.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -373,10 +366,7 @@ namespace Twilio.Rest.Sync.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -389,7 +379,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Documents/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Sync/V1/Service/SyncList/SyncListItemResource.cs
+++ b/src/Twilio/Rest/Sync/V1/Service/SyncList/SyncListItemResource.cs
@@ -55,7 +55,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Items/" + options.PathIndex + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -131,7 +130,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
                 HttpMethod.Delete,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Items/" + options.PathIndex + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -204,7 +202,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Items",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -294,7 +291,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Items",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -414,10 +410,7 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -434,10 +427,7 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -450,7 +440,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Items/" + options.PathIndex + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Sync/V1/Service/SyncList/SyncListPermissionResource.cs
+++ b/src/Twilio/Rest/Sync/V1/Service/SyncList/SyncListPermissionResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -107,7 +106,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
                 HttpMethod.Delete,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -185,7 +183,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Permissions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -294,10 +291,7 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -315,10 +309,7 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -331,7 +322,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncList
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathListSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Sync/V1/Service/SyncListResource.cs
+++ b/src/Twilio/Rest/Sync/V1/Service/SyncListResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -98,7 +97,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -168,7 +166,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -248,7 +245,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -328,7 +324,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Lists",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -431,10 +426,7 @@ namespace Twilio.Rest.Sync.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -451,10 +443,7 @@ namespace Twilio.Rest.Sync.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Sync/V1/Service/SyncMap/SyncMapItemResource.cs
+++ b/src/Twilio/Rest/Sync/V1/Service/SyncMap/SyncMapItemResource.cs
@@ -55,7 +55,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Items/" + options.PathKey + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -131,7 +130,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
                 HttpMethod.Delete,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Items/" + options.PathKey + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -204,7 +202,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Items",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -298,7 +295,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Items",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -417,10 +413,7 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -437,10 +430,7 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -453,7 +443,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Items/" + options.PathKey + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Sync/V1/Service/SyncMap/SyncMapPermissionResource.cs
+++ b/src/Twilio/Rest/Sync/V1/Service/SyncMap/SyncMapPermissionResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -106,7 +105,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
                 HttpMethod.Delete,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -184,7 +182,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Permissions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -293,10 +290,7 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -314,10 +308,7 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -330,7 +321,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncMap
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathMapSid + "/Permissions/" + options.PathIdentity + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Sync/V1/Service/SyncMapResource.cs
+++ b/src/Twilio/Rest/Sync/V1/Service/SyncMapResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -98,7 +97,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -168,7 +166,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -248,7 +245,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -328,7 +324,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Maps",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -431,10 +426,7 @@ namespace Twilio.Rest.Sync.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -451,10 +443,7 @@ namespace Twilio.Rest.Sync.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Sync/V1/Service/SyncStream/StreamMessageResource.cs
+++ b/src/Twilio/Rest/Sync/V1/Service/SyncStream/StreamMessageResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Sync.V1.Service.SyncStream
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Streams/" + options.PathStreamSid + "/Messages",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Sync/V1/Service/SyncStreamResource.cs
+++ b/src/Twilio/Rest/Sync/V1/Service/SyncStreamResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Streams/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -98,7 +97,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Delete,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Streams/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -168,7 +166,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Streams",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -244,7 +241,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Streams/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -320,7 +316,6 @@ namespace Twilio.Rest.Sync.V1.Service
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathServiceSid + "/Streams",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -423,10 +418,7 @@ namespace Twilio.Rest.Sync.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -443,10 +435,7 @@ namespace Twilio.Rest.Sync.V1.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Sync/V1/ServiceResource.cs
+++ b/src/Twilio/Rest/Sync/V1/ServiceResource.cs
@@ -28,7 +28,6 @@ namespace Twilio.Rest.Sync.V1
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -95,7 +94,6 @@ namespace Twilio.Rest.Sync.V1
                 HttpMethod.Delete,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -161,7 +159,6 @@ namespace Twilio.Rest.Sync.V1
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -261,7 +258,6 @@ namespace Twilio.Rest.Sync.V1
                 HttpMethod.Get,
                 Rest.Domain.Sync,
                 "/v1/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -360,10 +356,7 @@ namespace Twilio.Rest.Sync.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -380,10 +373,7 @@ namespace Twilio.Rest.Sync.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Sync,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Sync)
             );
 
             var response = client.Request(request);
@@ -396,7 +386,6 @@ namespace Twilio.Rest.Sync.V1
                 HttpMethod.Post,
                 Rest.Domain.Sync,
                 "/v1/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/ActivityResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/ActivityResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Activities/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Activities/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -172,7 +170,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Delete,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Activities/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -242,7 +239,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Activities",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -353,10 +349,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -373,10 +366,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -389,7 +379,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Activities",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/EventResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/EventResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Events/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Events",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -243,10 +241,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -263,10 +258,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/Task/ReservationResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/Task/ReservationResource.cs
@@ -93,7 +93,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Task
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Tasks/" + options.PathTaskSid + "/Reservations",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -206,10 +205,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Task
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -226,10 +222,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Task
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -242,7 +235,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Task
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Tasks/" + options.PathTaskSid + "/Reservations/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -318,7 +310,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Task
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Tasks/" + options.PathTaskSid + "/Reservations/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskChannelResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskChannelResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskChannels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskChannels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -199,10 +197,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -219,10 +214,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -235,7 +227,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskChannels/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -317,7 +308,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Delete,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskChannels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -387,7 +377,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskChannels",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueueCumulativeStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueueCumulativeStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.TaskQueue
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskQueues/" + options.PathTaskQueueSid + "/CumulativeStatistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueueRealTimeStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueueRealTimeStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.TaskQueue
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskQueues/" + options.PathTaskQueueSid + "/RealTimeStatistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueueStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueueStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.TaskQueue
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskQueues/" + options.PathTaskQueueSid + "/Statistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueuesStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueue/TaskQueuesStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.TaskQueue
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskQueues/Statistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -157,10 +156,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.TaskQueue
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -178,10 +174,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.TaskQueue
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueueResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskQueueResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskQueues/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskQueues/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -214,7 +212,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskQueues",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -329,10 +326,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -349,10 +343,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -365,7 +356,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskQueues",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -463,7 +453,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Delete,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/TaskQueues/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/TaskResource.cs
@@ -44,7 +44,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Tasks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -114,7 +113,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Tasks/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -206,7 +204,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Delete,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Tasks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -276,7 +273,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Tasks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -417,10 +413,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -437,10 +430,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -453,7 +443,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Tasks",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/ReservationResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/ReservationResource.cs
@@ -79,7 +79,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/" + options.PathWorkerSid + "/Reservations",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -194,10 +193,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -214,10 +210,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -230,7 +223,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/" + options.PathWorkerSid + "/Reservations/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -308,7 +300,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/" + options.PathWorkerSid + "/Reservations/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkerChannelResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkerChannelResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/" + options.PathWorkerSid + "/Channels",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -134,10 +133,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -154,10 +150,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -170,7 +163,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/" + options.PathWorkerSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -246,7 +238,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/" + options.PathWorkerSid + "/Channels/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkerStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkerStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/" + options.PathWorkerSid + "/Statistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkersCumulativeStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkersCumulativeStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/CumulativeStatistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkersRealTimeStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkersRealTimeStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/RealTimeStatistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkersStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/Worker/WorkersStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Worker
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/Statistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/WorkerResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/WorkerResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -157,10 +156,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -177,10 +173,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -193,7 +186,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -273,7 +265,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -343,7 +334,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -431,7 +421,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Delete,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workers/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/Workflow/WorkflowCumulativeStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/Workflow/WorkflowCumulativeStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Workflow
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workflows/" + options.PathWorkflowSid + "/CumulativeStatistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/Workflow/WorkflowRealTimeStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/Workflow/WorkflowRealTimeStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Workflow
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workflows/" + options.PathWorkflowSid + "/RealTimeStatistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/Workflow/WorkflowStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/Workflow/WorkflowStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace.Workflow
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workflows/" + options.PathWorkflowSid + "/Statistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/WorkflowResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/WorkflowResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workflows/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workflows/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -196,7 +194,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Delete,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workflows/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -266,7 +263,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workflows",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -373,10 +369,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -393,10 +386,7 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -409,7 +399,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Workflows",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/WorkspaceCumulativeStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/WorkspaceCumulativeStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/CumulativeStatistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/WorkspaceRealTimeStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/WorkspaceRealTimeStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/RealTimeStatistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/Workspace/WorkspaceStatisticsResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/Workspace/WorkspaceStatisticsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Taskrouter.V1.Workspace
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathWorkspaceSid + "/Statistics",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Taskrouter/V1/WorkspaceResource.cs
+++ b/src/Twilio/Rest/Taskrouter/V1/WorkspaceResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Taskrouter.V1
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -107,7 +106,6 @@ namespace Twilio.Rest.Taskrouter.V1
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -209,7 +207,6 @@ namespace Twilio.Rest.Taskrouter.V1
                 HttpMethod.Get,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -312,10 +309,7 @@ namespace Twilio.Rest.Taskrouter.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -332,10 +326,7 @@ namespace Twilio.Rest.Taskrouter.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Taskrouter,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Taskrouter)
             );
 
             var response = client.Request(request);
@@ -348,7 +339,6 @@ namespace Twilio.Rest.Taskrouter.V1
                 HttpMethod.Post,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -438,7 +428,6 @@ namespace Twilio.Rest.Taskrouter.V1
                 HttpMethod.Delete,
                 Rest.Domain.Taskrouter,
                 "/v1/Workspaces/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Trunking/V1/Trunk/CredentialListResource.cs
+++ b/src/Twilio/Rest/Trunking/V1/Trunk/CredentialListResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Get,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/CredentialLists/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Delete,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/CredentialLists/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -166,7 +164,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Post,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/CredentialLists",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -238,7 +235,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Get,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/CredentialLists",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -342,10 +338,7 @@ namespace Twilio.Rest.Trunking.V1.Trunk
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Trunking,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Trunking)
             );
 
             var response = client.Request(request);
@@ -362,10 +355,7 @@ namespace Twilio.Rest.Trunking.V1.Trunk
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Trunking,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Trunking)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Trunking/V1/Trunk/IpAccessControlListResource.cs
+++ b/src/Twilio/Rest/Trunking/V1/Trunk/IpAccessControlListResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Get,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/IpAccessControlLists/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -97,7 +96,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Delete,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/IpAccessControlLists/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -167,7 +165,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Post,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/IpAccessControlLists",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -242,7 +239,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Get,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/IpAccessControlLists",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -347,10 +343,7 @@ namespace Twilio.Rest.Trunking.V1.Trunk
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Trunking,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Trunking)
             );
 
             var response = client.Request(request);
@@ -368,10 +361,7 @@ namespace Twilio.Rest.Trunking.V1.Trunk
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Trunking,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Trunking)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Trunking/V1/Trunk/OriginationUrlResource.cs
+++ b/src/Twilio/Rest/Trunking/V1/Trunk/OriginationUrlResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Get,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/OriginationUrls/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Delete,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/OriginationUrls/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -166,7 +164,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Post,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/OriginationUrls",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -256,7 +253,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Get,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/OriginationUrls",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -360,10 +356,7 @@ namespace Twilio.Rest.Trunking.V1.Trunk
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Trunking,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Trunking)
             );
 
             var response = client.Request(request);
@@ -380,10 +373,7 @@ namespace Twilio.Rest.Trunking.V1.Trunk
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Trunking,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Trunking)
             );
 
             var response = client.Request(request);
@@ -396,7 +386,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Post,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/OriginationUrls/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Trunking/V1/Trunk/PhoneNumberResource.cs
+++ b/src/Twilio/Rest/Trunking/V1/Trunk/PhoneNumberResource.cs
@@ -42,7 +42,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Get,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/PhoneNumbers/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -112,7 +111,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Delete,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/PhoneNumbers/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -182,7 +180,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Post,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/PhoneNumbers",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -254,7 +251,6 @@ namespace Twilio.Rest.Trunking.V1.Trunk
                 HttpMethod.Get,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathTrunkSid + "/PhoneNumbers",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -357,10 +353,7 @@ namespace Twilio.Rest.Trunking.V1.Trunk
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Trunking,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Trunking)
             );
 
             var response = client.Request(request);
@@ -377,10 +370,7 @@ namespace Twilio.Rest.Trunking.V1.Trunk
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Trunking,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Trunking)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Trunking/V1/TrunkResource.cs
+++ b/src/Twilio/Rest/Trunking/V1/TrunkResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Trunking.V1
                 HttpMethod.Get,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -108,7 +107,6 @@ namespace Twilio.Rest.Trunking.V1
                 HttpMethod.Delete,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -174,7 +172,6 @@ namespace Twilio.Rest.Trunking.V1
                 HttpMethod.Post,
                 Rest.Domain.Trunking,
                 "/v1/Trunks",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -268,7 +265,6 @@ namespace Twilio.Rest.Trunking.V1
                 HttpMethod.Get,
                 Rest.Domain.Trunking,
                 "/v1/Trunks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -367,10 +363,7 @@ namespace Twilio.Rest.Trunking.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Trunking,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Trunking)
             );
 
             var response = client.Request(request);
@@ -387,10 +380,7 @@ namespace Twilio.Rest.Trunking.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Trunking,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Trunking)
             );
 
             var response = client.Request(request);
@@ -403,7 +393,6 @@ namespace Twilio.Rest.Trunking.V1
                 HttpMethod.Post,
                 Rest.Domain.Trunking,
                 "/v1/Trunks/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Verify/V2/Service/MessagingConfigurationResource.cs
+++ b/src/Twilio/Rest/Verify/V2/Service/MessagingConfigurationResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/MessagingConfigurations",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -103,7 +102,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/MessagingConfigurations/" + options.PathCountry + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -180,7 +178,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/MessagingConfigurations/" + options.PathCountry + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -253,7 +250,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/MessagingConfigurations",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -358,10 +354,7 @@ namespace Twilio.Rest.Verify.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Verify,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Verify)
             );
 
             var response = client.Request(request);
@@ -379,10 +372,7 @@ namespace Twilio.Rest.Verify.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Verify,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Verify)
             );
 
             var response = client.Request(request);
@@ -395,7 +385,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Delete,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/MessagingConfigurations/" + options.PathCountry + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Verify/V2/Service/RateLimit/BucketResource.cs
+++ b/src/Twilio/Rest/Verify/V2/Service/RateLimit/BucketResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Verify.V2.Service.RateLimit
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/RateLimits/" + options.PathRateLimitSid + "/Buckets",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -106,7 +105,6 @@ namespace Twilio.Rest.Verify.V2.Service.RateLimit
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/RateLimits/" + options.PathRateLimitSid + "/Buckets/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -190,7 +188,6 @@ namespace Twilio.Rest.Verify.V2.Service.RateLimit
                 HttpMethod.Get,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/RateLimits/" + options.PathRateLimitSid + "/Buckets/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -266,7 +263,6 @@ namespace Twilio.Rest.Verify.V2.Service.RateLimit
                 HttpMethod.Get,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/RateLimits/" + options.PathRateLimitSid + "/Buckets",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -373,10 +369,7 @@ namespace Twilio.Rest.Verify.V2.Service.RateLimit
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Verify,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Verify)
             );
 
             var response = client.Request(request);
@@ -393,10 +386,7 @@ namespace Twilio.Rest.Verify.V2.Service.RateLimit
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Verify,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Verify)
             );
 
             var response = client.Request(request);
@@ -409,7 +399,6 @@ namespace Twilio.Rest.Verify.V2.Service.RateLimit
                 HttpMethod.Delete,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/RateLimits/" + options.PathRateLimitSid + "/Buckets/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Verify/V2/Service/RateLimitResource.cs
+++ b/src/Twilio/Rest/Verify/V2/Service/RateLimitResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/RateLimits",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -102,7 +101,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/RateLimits/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -178,7 +176,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/RateLimits/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -248,7 +245,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/RateLimits",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -351,10 +347,7 @@ namespace Twilio.Rest.Verify.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Verify,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Verify)
             );
 
             var response = client.Request(request);
@@ -371,10 +364,7 @@ namespace Twilio.Rest.Verify.V2.Service
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Verify,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Verify)
             );
 
             var response = client.Request(request);
@@ -387,7 +377,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Delete,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/RateLimits/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Verify/V2/Service/VerificationCheckResource.cs
+++ b/src/Twilio/Rest/Verify/V2/Service/VerificationCheckResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/VerificationCheck",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Verify/V2/Service/VerificationResource.cs
+++ b/src/Twilio/Rest/Verify/V2/Service/VerificationResource.cs
@@ -54,7 +54,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/Verifications",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -166,7 +165,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/Verifications/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -242,7 +240,6 @@ namespace Twilio.Rest.Verify.V2.Service
                 HttpMethod.Get,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathServiceSid + "/Verifications/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Verify/V2/ServiceResource.cs
+++ b/src/Twilio/Rest/Verify/V2/ServiceResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Verify.V2
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -124,7 +123,6 @@ namespace Twilio.Rest.Verify.V2
                 HttpMethod.Get,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -191,7 +189,6 @@ namespace Twilio.Rest.Verify.V2
                 HttpMethod.Delete,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -257,7 +254,6 @@ namespace Twilio.Rest.Verify.V2
                 HttpMethod.Get,
                 Rest.Domain.Verify,
                 "/v2/Services",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -356,10 +352,7 @@ namespace Twilio.Rest.Verify.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Verify,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Verify)
             );
 
             var response = client.Request(request);
@@ -376,10 +369,7 @@ namespace Twilio.Rest.Verify.V2
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Verify,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Verify)
             );
 
             var response = client.Request(request);
@@ -392,7 +382,6 @@ namespace Twilio.Rest.Verify.V2
                 HttpMethod.Post,
                 Rest.Domain.Verify,
                 "/v2/Services/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Video/V1/CompositionHookResource.cs
+++ b/src/Twilio/Rest/Video/V1/CompositionHookResource.cs
@@ -43,7 +43,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/CompositionHooks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/CompositionHooks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -232,10 +230,7 @@ namespace Twilio.Rest.Video.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -253,10 +248,7 @@ namespace Twilio.Rest.Video.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -269,7 +261,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Delete,
                 Rest.Domain.Video,
                 "/v1/CompositionHooks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -335,7 +326,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Post,
                 Rest.Domain.Video,
                 "/v1/CompositionHooks",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -445,7 +435,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Post,
                 Rest.Domain.Video,
                 "/v1/CompositionHooks/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Video/V1/CompositionResource.cs
+++ b/src/Twilio/Rest/Video/V1/CompositionResource.cs
@@ -59,7 +59,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Compositions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -126,7 +125,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Compositions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -245,10 +243,7 @@ namespace Twilio.Rest.Video.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -265,10 +260,7 @@ namespace Twilio.Rest.Video.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -281,7 +273,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Delete,
                 Rest.Domain.Video,
                 "/v1/Compositions/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -347,7 +338,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Post,
                 Rest.Domain.Video,
                 "/v1/Compositions",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Video/V1/CompositionSettingsResource.cs
+++ b/src/Twilio/Rest/Video/V1/CompositionSettingsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/CompositionSettings/Default",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -91,7 +90,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Post,
                 Rest.Domain.Video,
                 "/v1/CompositionSettings/Default",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Video/V1/RecordingResource.cs
+++ b/src/Twilio/Rest/Video/V1/RecordingResource.cs
@@ -84,7 +84,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Recordings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -151,7 +150,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Recordings",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -278,10 +276,7 @@ namespace Twilio.Rest.Video.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -298,10 +293,7 @@ namespace Twilio.Rest.Video.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -314,7 +306,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Delete,
                 Rest.Domain.Video,
                 "/v1/Recordings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Video/V1/RecordingSettingsResource.cs
+++ b/src/Twilio/Rest/Video/V1/RecordingSettingsResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/RecordingSettings/Default",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -90,7 +89,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Post,
                 Rest.Domain.Video,
                 "/v1/RecordingSettings/Default",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Video/V1/Room/Participant/PublishedTrackResource.cs
+++ b/src/Twilio/Rest/Video/V1/Room/Participant/PublishedTrackResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Video.V1.Room.Participant
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Participants/" + options.PathParticipantSid + "/PublishedTracks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -117,7 +116,6 @@ namespace Twilio.Rest.Video.V1.Room.Participant
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Participants/" + options.PathParticipantSid + "/PublishedTracks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -229,10 +227,7 @@ namespace Twilio.Rest.Video.V1.Room.Participant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -249,10 +244,7 @@ namespace Twilio.Rest.Video.V1.Room.Participant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Video/V1/Room/Participant/SubscribeRulesResource.cs
+++ b/src/Twilio/Rest/Video/V1/Room/Participant/SubscribeRulesResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Video.V1.Room.Participant
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Participants/" + options.PathParticipantSid + "/SubscribeRules",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -101,7 +100,6 @@ namespace Twilio.Rest.Video.V1.Room.Participant
                 HttpMethod.Post,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Participants/" + options.PathParticipantSid + "/SubscribeRules",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Video/V1/Room/Participant/SubscribedTrackResource.cs
+++ b/src/Twilio/Rest/Video/V1/Room/Participant/SubscribedTrackResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Video.V1.Room.Participant
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Participants/" + options.PathParticipantSid + "/SubscribedTracks/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -121,7 +120,6 @@ namespace Twilio.Rest.Video.V1.Room.Participant
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Participants/" + options.PathParticipantSid + "/SubscribedTracks",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -229,10 +227,7 @@ namespace Twilio.Rest.Video.V1.Room.Participant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -250,10 +245,7 @@ namespace Twilio.Rest.Video.V1.Room.Participant
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Video/V1/Room/ParticipantResource.cs
+++ b/src/Twilio/Rest/Video/V1/Room/ParticipantResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Video.V1.Room
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Participants/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -110,7 +109,6 @@ namespace Twilio.Rest.Video.V1.Room
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Participants",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -229,10 +227,7 @@ namespace Twilio.Rest.Video.V1.Room
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -249,10 +244,7 @@ namespace Twilio.Rest.Video.V1.Room
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -265,7 +257,6 @@ namespace Twilio.Rest.Video.V1.Room
                 HttpMethod.Post,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Participants/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Video/V1/Room/RoomRecordingResource.cs
+++ b/src/Twilio/Rest/Video/V1/Room/RoomRecordingResource.cs
@@ -84,7 +84,6 @@ namespace Twilio.Rest.Video.V1.Room
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Recordings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -154,7 +153,6 @@ namespace Twilio.Rest.Video.V1.Room
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Recordings",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -278,10 +276,7 @@ namespace Twilio.Rest.Video.V1.Room
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -298,10 +293,7 @@ namespace Twilio.Rest.Video.V1.Room
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -314,7 +306,6 @@ namespace Twilio.Rest.Video.V1.Room
                 HttpMethod.Delete,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathRoomSid + "/Recordings/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Video/V1/RoomResource.cs
+++ b/src/Twilio/Rest/Video/V1/RoomResource.cs
@@ -68,7 +68,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -135,7 +134,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Post,
                 Rest.Domain.Video,
                 "/v1/Rooms",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -237,7 +235,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Get,
                 Rest.Domain.Video,
                 "/v1/Rooms",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -352,10 +349,7 @@ namespace Twilio.Rest.Video.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -372,10 +366,7 @@ namespace Twilio.Rest.Video.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Video,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Video)
             );
 
             var response = client.Request(request);
@@ -388,7 +379,6 @@ namespace Twilio.Rest.Video.V1
                 HttpMethod.Post,
                 Rest.Domain.Video,
                 "/v1/Rooms/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Voice/V1/DialingPermissions/BulkCountryUpdateResource.cs
+++ b/src/Twilio/Rest/Voice/V1/DialingPermissions/BulkCountryUpdateResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Voice.V1.DialingPermissions
                 HttpMethod.Post,
                 Rest.Domain.Voice,
                 "/v1/DialingPermissions/BulkCountryUpdates",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Voice/V1/DialingPermissions/Country/HighriskSpecialPrefixResource.cs
+++ b/src/Twilio/Rest/Voice/V1/DialingPermissions/Country/HighriskSpecialPrefixResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Voice.V1.DialingPermissions.Country
                 HttpMethod.Get,
                 Rest.Domain.Voice,
                 "/v1/DialingPermissions/Countries/" + options.PathIsoCode + "/HighRiskSpecialPrefixes",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -138,10 +137,7 @@ namespace Twilio.Rest.Voice.V1.DialingPermissions.Country
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Voice,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Voice)
             );
 
             var response = client.Request(request);
@@ -159,10 +155,7 @@ namespace Twilio.Rest.Voice.V1.DialingPermissions.Country
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Voice,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Voice)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Voice/V1/DialingPermissions/CountryResource.cs
+++ b/src/Twilio/Rest/Voice/V1/DialingPermissions/CountryResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Voice.V1.DialingPermissions
                 HttpMethod.Get,
                 Rest.Domain.Voice,
                 "/v1/DialingPermissions/Countries/" + options.PathIsoCode + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -96,7 +95,6 @@ namespace Twilio.Rest.Voice.V1.DialingPermissions
                 HttpMethod.Get,
                 Rest.Domain.Voice,
                 "/v1/DialingPermissions/Countries",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -225,10 +223,7 @@ namespace Twilio.Rest.Voice.V1.DialingPermissions
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Voice,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Voice)
             );
 
             var response = client.Request(request);
@@ -245,10 +240,7 @@ namespace Twilio.Rest.Voice.V1.DialingPermissions
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Voice,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Voice)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Voice/V1/DialingPermissions/SettingsResource.cs
+++ b/src/Twilio/Rest/Voice/V1/DialingPermissions/SettingsResource.cs
@@ -29,7 +29,6 @@ namespace Twilio.Rest.Voice.V1.DialingPermissions
                 HttpMethod.Get,
                 Rest.Domain.Voice,
                 "/v1/Settings",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -93,7 +92,6 @@ namespace Twilio.Rest.Voice.V1.DialingPermissions
                 HttpMethod.Post,
                 Rest.Domain.Voice,
                 "/v1/Settings",
-                client.Region,
                 postParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Wireless/V1/CommandResource.cs
+++ b/src/Twilio/Rest/Wireless/V1/CommandResource.cs
@@ -82,7 +82,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Get,
                 Rest.Domain.Wireless,
                 "/v1/Commands/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -149,7 +148,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Get,
                 Rest.Domain.Wireless,
                 "/v1/Commands",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -264,10 +262,7 @@ namespace Twilio.Rest.Wireless.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);
@@ -284,10 +279,7 @@ namespace Twilio.Rest.Wireless.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);
@@ -300,7 +292,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Post,
                 Rest.Domain.Wireless,
                 "/v1/Commands",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -392,7 +383,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Delete,
                 Rest.Domain.Wireless,
                 "/v1/Commands/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Wireless/V1/RatePlanResource.cs
+++ b/src/Twilio/Rest/Wireless/V1/RatePlanResource.cs
@@ -40,7 +40,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Get,
                 Rest.Domain.Wireless,
                 "/v1/RatePlans",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -139,10 +138,7 @@ namespace Twilio.Rest.Wireless.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);
@@ -159,10 +155,7 @@ namespace Twilio.Rest.Wireless.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);
@@ -175,7 +168,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Get,
                 Rest.Domain.Wireless,
                 "/v1/RatePlans/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -242,7 +234,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Post,
                 Rest.Domain.Wireless,
                 "/v1/RatePlans",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -362,7 +353,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Post,
                 Rest.Domain.Wireless,
                 "/v1/RatePlans/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -438,7 +428,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Delete,
                 Rest.Domain.Wireless,
                 "/v1/RatePlans/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Wireless/V1/Sim/DataSessionResource.cs
+++ b/src/Twilio/Rest/Wireless/V1/Sim/DataSessionResource.cs
@@ -26,7 +26,6 @@ namespace Twilio.Rest.Wireless.V1.Sim
                 HttpMethod.Get,
                 Rest.Domain.Wireless,
                 "/v1/Sims/" + options.PathSimSid + "/DataSessions",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -137,10 +136,7 @@ namespace Twilio.Rest.Wireless.V1.Sim
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);
@@ -157,10 +153,7 @@ namespace Twilio.Rest.Wireless.V1.Sim
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Wireless/V1/Sim/UsageRecordResource.cs
+++ b/src/Twilio/Rest/Wireless/V1/Sim/UsageRecordResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Wireless.V1.Sim
                 HttpMethod.Get,
                 Rest.Domain.Wireless,
                 "/v1/Sims/" + options.PathSimSid + "/UsageRecords",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -156,10 +155,7 @@ namespace Twilio.Rest.Wireless.V1.Sim
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);
@@ -176,10 +172,7 @@ namespace Twilio.Rest.Wireless.V1.Sim
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);

--- a/src/Twilio/Rest/Wireless/V1/SimResource.cs
+++ b/src/Twilio/Rest/Wireless/V1/SimResource.cs
@@ -58,7 +58,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Get,
                 Rest.Domain.Wireless,
                 "/v1/Sims/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -125,7 +124,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Get,
                 Rest.Domain.Wireless,
                 "/v1/Sims",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -244,10 +242,7 @@ namespace Twilio.Rest.Wireless.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);
@@ -264,10 +259,7 @@ namespace Twilio.Rest.Wireless.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);
@@ -280,7 +272,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Post,
                 Rest.Domain.Wireless,
                 "/v1/Sims/" + options.PathSid + "",
-                client.Region,
                 postParams: options.GetParams()
             );
         }
@@ -428,7 +419,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Delete,
                 Rest.Domain.Wireless,
                 "/v1/Sims/" + options.PathSid + "",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }

--- a/src/Twilio/Rest/Wireless/V1/UsageRecordResource.cs
+++ b/src/Twilio/Rest/Wireless/V1/UsageRecordResource.cs
@@ -41,7 +41,6 @@ namespace Twilio.Rest.Wireless.V1
                 HttpMethod.Get,
                 Rest.Domain.Wireless,
                 "/v1/UsageRecords",
-                client.Region,
                 queryParams: options.GetParams()
             );
         }
@@ -152,10 +151,7 @@ namespace Twilio.Rest.Wireless.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetNextPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetNextPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);
@@ -172,10 +168,7 @@ namespace Twilio.Rest.Wireless.V1
         {
             var request = new Request(
                 HttpMethod.Get,
-                page.GetPreviousPageUrl(
-                    Rest.Domain.Wireless,
-                    client.Region
-                )
+                page.GetPreviousPageUrl(Rest.Domain.Wireless)
             );
 
             var response = client.Request(request);


### PR DESCRIPTION
This drops the client region param when creating requests or building request URLs for paging in. This is no longer needed as the client will do this when sending the request.