### PR TITLE
feat: include API response headers in 'Last Response'

### DIFF
--- a/src/Twilio/Http/Net35/WebRequestClient.cs
+++ b/src/Twilio/Http/Net35/WebRequestClient.cs
@@ -37,7 +37,7 @@ namespace Twilio.Http.Net35
             {
                 IHttpWebResponseWrapper response = httpRequest.GetResponse();
                 string content = GetResponseContent(response);
-                this.LastResponse = new Response(response.StatusCode, content);
+                this.LastResponse = new Response(response.StatusCode, content, response.Headers);
             }
             catch (WebExceptionWrapper e)
             {
@@ -48,7 +48,7 @@ namespace Twilio.Http.Net35
                 }
                 // Non 2XX status code
                 IHttpWebResponseWrapper errorResponse = e.Response;
-                this.LastResponse = new Response(errorResponse.StatusCode, GetResponseContent(errorResponse));
+                this.LastResponse = new Response(errorResponse.StatusCode, GetResponseContent(errorResponse), errorResponse.Headers);
             }
             return this.LastResponse;
         }

--- a/src/Twilio/Http/Net35/WebRequestWrappers.cs
+++ b/src/Twilio/Http/Net35/WebRequestWrappers.cs
@@ -35,6 +35,7 @@ namespace Twilio.Http.Net35
     {
         HttpStatusCode StatusCode { get; set; }
         Stream GetResponseStream();
+        WebHeaderCollection Headers { get; }
     }
 
     public class HttpWebRequestWrapper : IHttpWebRequestWrapper
@@ -124,6 +125,11 @@ namespace Twilio.Http.Net35
         public Stream GetResponseStream()
         {
             return this._httpWebResponse.GetResponseStream();
+        }
+
+        public WebHeaderCollection Headers
+        {
+            get { return this._httpWebResponse.Headers; }
         }
     }
 

--- a/src/Twilio/Http/Response.cs
+++ b/src/Twilio/Http/Response.cs
@@ -1,5 +1,10 @@
 using System.Net;
-using System.Net.Http.Headers;
+
+#if NET35
+using Headers = System.Net.WebHeaderCollection;
+#else
+using Headers = System.Net.Http.Headers.HttpResponseHeaders;
+#endif
 
 namespace Twilio.Http
 {
@@ -21,7 +26,7 @@ namespace Twilio.Http
         /// <summary>
         /// Headers
         /// </summary>
-        public HttpResponseHeaders Headers { get; }
+        public Headers Headers { get; }
 
         /// <summary>
         /// Create a new Response
@@ -29,7 +34,7 @@ namespace Twilio.Http
         /// <param name="statusCode">HTTP status code</param>
         /// <param name="content">Content string</param>
         /// <param name="headers">Headers</param>
-        public Response(HttpStatusCode statusCode, string content, HttpResponseHeaders headers = null)
+        public Response(HttpStatusCode statusCode, string content, Headers headers = null)
         {
             StatusCode = statusCode;
             Content = content;

--- a/src/Twilio/Http/Response.cs
+++ b/src/Twilio/Http/Response.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace Twilio.Http
 {
@@ -18,14 +19,21 @@ namespace Twilio.Http
         public string Content { get; }
 
         /// <summary>
-        /// Create a new Response 
+        /// Headers
+        /// </summary>
+        public HttpResponseHeaders Headers { get; }
+
+        /// <summary>
+        /// Create a new Response
         /// </summary>
         /// <param name="statusCode">HTTP status code</param>
         /// <param name="content">Content string</param>
-        public Response (HttpStatusCode statusCode, string content)
+        /// <param name="headers">Headers</param>
+        public Response(HttpStatusCode statusCode, string content, HttpResponseHeaders headers = null)
         {
             StatusCode = statusCode;
             Content = content;
+            Headers = headers;
         }
     }
 }

--- a/src/Twilio/Http/SystemNetHttpClient.cs
+++ b/src/Twilio/Http/SystemNetHttpClient.cs
@@ -13,11 +13,11 @@ namespace Twilio.Http
     /// </summary>
     public class SystemNetHttpClient : HttpClient
     {
-        #if NET451
+#if NET451
         private string PlatVersion = " (.NET Framework 4.5.1+)";
-        #else
+#else
         private string PlatVersion = $" ({RuntimeInformation.FrameworkDescription})";
-        #endif
+#endif
 
         private readonly System.Net.Http.HttpClient _httpClient;
 
@@ -73,7 +73,7 @@ namespace Twilio.Http
             // Create and return a new Response. Keep a reference to the last
             // response for debugging, but don't return it as it may be shared
             // among threads.
-            var response = new Response(httpResponse.StatusCode, await reader.ReadToEndAsync().ConfigureAwait(false));
+            var response = new Response(httpResponse.StatusCode, await reader.ReadToEndAsync().ConfigureAwait(false), httpResponse.Headers);
             this.LastResponse = response;
             return response;
         }


### PR DESCRIPTION
The default HTTP client stores 'Last Request' and 'Last Response' information for access to more data about the raw API request/response. The response object did not contain the headers until now.