### PR TITLE
fix: Change Default Logo from .ico to .png in NuGet

### DIFF
--- a/src/Twilio/Twilio.csproj
+++ b/src/Twilio/Twilio.csproj
@@ -16,7 +16,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Twilio</AssemblyName>
     <PackageTags>REST;SMS;voice;telephony;phone;twilio;twiml;video;wireless;api</PackageTags>
-    <PackageIconUrl>https://www.twilio.com/marketing/bundles/marketing/img/favicons/favicon.ico</PackageIconUrl>
+    <PackageIconUrl>https://www.twilio.com/docs/static/company/img/logos/red/twilio-mark-red.898073bba.png</PackageIconUrl>
     <PackageProjectUrl>http://github.com/twilio/twilio-csharp</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/twilio/twilio-csharp/blob/master/LICENSE.md</PackageLicenseUrl>
     <RepositoryUrl>http://github.com/twilio/twilio-csharp</RepositoryUrl>


### PR DESCRIPTION
# Fixes #

On Visual Studio the current icon for `twilio-csharp` appears to be scrambled. 

This change modifies the `.ico` file with `.png`.

Note: I wasn't entirely sure how to test this given that this is hosted with NuGet, but perhaps there is additional functionality that can be utilized for testing.

<img width="519" alt="Screen Shot 2020-07-16 at 2 17 40 PM" src="https://user-images.githubusercontent.com/918117/87726072-31451980-c773-11ea-972d-f0eca6d63631.png">


### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [X]  I have titled the PR appropriately
- [X] I have updated my branch with the master branch
- [] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation about the functionality in the appropriate .md file
- [X] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
