### PR TITLE
feat: Validate AccountSid on Init

### DIFF
--- a/src/Twilio/Clients/TwilioRestClient.cs
+++ b/src/Twilio/Clients/TwilioRestClient.cs
@@ -28,7 +28,7 @@ namespace Twilio.Clients
         /// <summary>
         /// Account SID to use for requests
         /// </summary>
-        public string AccountSid { get; }
+        public string AccountSid => _accountSid ?? throw new ArgumentException("AccountSID not set in " + nameof(TwilioClient) + "." + nameof(TwilioClient.Init));
 
         /// <summary>
         /// Twilio region to make requests to
@@ -42,6 +42,7 @@ namespace Twilio.Clients
 
         private readonly string _username;
         private readonly string _password;
+        private readonly string _accountSid;
 
         /// <summary>
         /// Constructor for a TwilioRestClient
@@ -65,7 +66,16 @@ namespace Twilio.Clients
             _username = username;
             _password = password;
 
-            AccountSid = accountSid ?? username;
+            _accountSid = accountSid;
+            //Validate prefix in accountSid, https://www.twilio.com/docs/glossary/what-is-a-sid#common-sid-prefixes
+            if (_accountSid?.StartsWith("AC", StringComparison.Ordinal) == false)
+                throw new ArgumentException("AccountSid must start with \"AC\"", nameof(accountSid));
+            if (_accountSid == null)
+            {
+                if (username.StartsWith("AC", StringComparison.Ordinal))
+                    _accountSid = username;
+            }
+
             HttpClient = httpClient ?? DefaultClient();
 
             Region = region;


### PR DESCRIPTION
 - Throws exception if a API call tries to use AccountSid when it's not set.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #531

For API:s that require AccountSid this PR will make sure that AccountSid is set.
Before "username" was assumed to be AccountSid which caused 404 errors for API calls that expected AccountSid to be set.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

