### PR TITLE
fix: use ReferenceAssemblies NuGet packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ solution: Twilio.sln
 mono: latest
 dotnet: 3.1
 
-env:
-  - FrameworkPathOverride=/usr/lib/mono/4.5/
-
 services:
   - docker
 

--- a/src/Twilio/Twilio.csproj
+++ b/src/Twilio/Twilio.csproj
@@ -52,4 +52,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="JWT" Version="1.3.4" />
   </ItemGroup>
+  <ItemGroup Condition="($(TargetFramework.StartsWith('net3')) OR $(TargetFramework.StartsWith('net4'))) AND '$(MSBuildRuntimeType)' == 'Core' AND '$(OS)' != 'Windows_NT'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/test/Twilio.Test/Twilio.Test.csproj
+++ b/test/Twilio.Test/Twilio.Test.csproj
@@ -10,8 +10,9 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.6.0" />
     <PackageReference Include="NSubstitute" Version="2.0.0-rc" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NUnitLite" Version="3.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System.Net" />
@@ -19,5 +20,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Twilio\Twilio.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="($(TargetFramework.StartsWith('net3')) OR $(TargetFramework.StartsWith('net4'))) AND '$(MSBuildRuntimeType)' == 'Core' AND '$(OS)' != 'Windows_NT'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Allows for building .NET Framework libraries on Linux without requiring Mono.

References:
https://medium.com/@dmaman/travis-ci-setup-for-multi-framework-solution-in-c-be32315c79d1
https://andrewlock.net/using-reference-assemblies-to-build-net-framework-libararies-on-linux-without-mono/

Fixes https://github.com/twilio/twilio-csharp/issues/536