### PR TITLE
fix: allow API redirect responses

### DIFF
--- a/src/Twilio/Clients/TwilioRestClient.cs
+++ b/src/Twilio/Clients/TwilioRestClient.cs
@@ -146,7 +146,7 @@ namespace Twilio.Clients
                 throw new ApiConnectionException("Connection Error: No response received.");
             }
 
-            if (response.StatusCode >= HttpStatusCode.OK && response.StatusCode < HttpStatusCode.Ambiguous)
+            if (response.StatusCode >= HttpStatusCode.OK && response.StatusCode < HttpStatusCode.BadRequest)
             {
                 return response;
             }

--- a/src/Twilio/Http/Net35/WebRequestWrappers.cs
+++ b/src/Twilio/Http/Net35/WebRequestWrappers.cs
@@ -48,6 +48,7 @@ namespace Twilio.Http.Net35
         public HttpWebRequestWrapper(Uri uri)
         {
             this._httpWebRequest = (HttpWebRequest) WebRequest.Create(uri);
+            this._httpWebRequest.AllowAutoRedirect=false;
         }
 
         public string UserAgent

--- a/src/Twilio/Http/SystemNetHttpClient.cs
+++ b/src/Twilio/Http/SystemNetHttpClient.cs
@@ -27,7 +27,7 @@ namespace Twilio.Http
         /// <param name="httpClient">HTTP client to use</param>
         public SystemNetHttpClient(System.Net.Http.HttpClient httpClient = null)
         {
-            _httpClient = httpClient ?? new System.Net.Http.HttpClient();
+            _httpClient = httpClient ?? new System.Net.Http.HttpClient(new HttpClientHandler() { AllowAutoRedirect = false });
         }
 
         /// <summary>
@@ -94,7 +94,8 @@ namespace Twilio.Http
             var libraryVersion = "twilio-csharp/" + AssemblyInfomation.AssemblyInformationalVersion + PlatVersion;
             httpRequest.Headers.TryAddWithoutValidation("User-Agent", libraryVersion);
 
-            foreach (var header in request.HeaderParams) {
+            foreach (var header in request.HeaderParams)
+            {
                 httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
 

--- a/test/Twilio.Test/Clients/TwilioRestClientTest.cs
+++ b/test/Twilio.Test/Clients/TwilioRestClientTest.cs
@@ -34,15 +34,20 @@ namespace Twilio.Tests.Clients
             // Exception type doesn't matter, just needs to match in IsInstanceOf below.
             client.MakeRequest(Arg.Any<Request>()).Throws(new InvalidOperationException());
 
-            try {
+            try
+            {
                 TwilioRestClient.ValidateSslCertificate(client);
                 Assert.Fail("Should have failed ssl verification");
-            } catch (CertificateValidationException e) {
+            }
+            catch (CertificateValidationException e)
+            {
                 Assert.IsInstanceOf(typeof(InvalidOperationException), e.GetBaseException());
                 Assert.AreEqual("Connection to api.twilio.com:8443 failed", e.Message);
                 Assert.IsNull(e.Response);
                 Assert.IsNotNull(e.Request);
-            } catch (Exception) {
+            }
+            catch (Exception)
+            {
                 Assert.Fail("Threw an unknown exception");
             }
         }
@@ -52,14 +57,19 @@ namespace Twilio.Tests.Clients
         {
             client.MakeRequest(Arg.Any<Request>()).Returns(new Response(HttpStatusCode.SwitchingProtocols, "NOTOK"));
 
-            try {
+            try
+            {
                 TwilioRestClient.ValidateSslCertificate(client);
                 Assert.Fail("Should have failed ssl verification");
-            } catch (CertificateValidationException e) {
+            }
+            catch (CertificateValidationException e)
+            {
                 Assert.AreEqual("Unexpected response from certificate endpoint", e.Message);
                 Assert.IsNotNull(e.Response);
                 Assert.IsNotNull(e.Request);
-            } catch (Exception) {
+            }
+            catch (Exception)
+            {
                 Assert.Fail("Threw an unknown exception");
             }
         }
@@ -76,12 +86,15 @@ namespace Twilio.Tests.Clients
                                         ""foo"": ""bar""
                                     }}";
             client.MakeRequest(Arg.Any<Request>()).Returns(new Response(HttpStatusCode.BadRequest, jsonResponse));
-            try {
-                Request request =  new Request(HttpMethod.Get,"https://www.contoso.com");
+            try
+            {
+                Request request = new Request(HttpMethod.Get, "https://www.contoso.com");
                 TwilioRestClient twilioClient = new TwilioRestClient("foo", "bar", null, null, client);
                 twilioClient.Request(request);
                 Assert.Fail("Should have failed");
-            } catch (ApiException e) {
+            }
+            catch (ApiException e)
+            {
                 Assert.AreEqual("Bad request", e.Message);
                 Assert.AreEqual(20001, e.Code);
                 Assert.AreEqual("https://www.twilio.com/docs/errors/20001", e.MoreInfo);
@@ -90,6 +103,15 @@ namespace Twilio.Tests.Clients
                 expectedDetails.Add("foo", "bar");
                 Assert.AreEqual(expectedDetails, e.Details);
             }
+        }
+
+        [Test]
+        public void TestRedirectResponse()
+        {
+            client.MakeRequest(Arg.Any<Request>()).Returns(new Response(HttpStatusCode.RedirectKeepVerb, "REDIRECT"));
+            Request request = new Request(HttpMethod.Get, "https://www.contoso.com");
+            TwilioRestClient twilioClient = new TwilioRestClient("foo", "bar", null, null, client);
+            twilioClient.Request(request);
         }
     }
 }


### PR DESCRIPTION
Fetching a BulkExport for a single day returns a `307` with the AWS URL for the file. With this change, the URL will now be included in the response.

Fixes https://github.com/twilio/twilio-csharp/issues/534