### PR TITLE
fix: Propagate Edge and Region properties from client to request when making async request

### DIFF
--- a/src/Twilio/Clients/TwilioRestClient.cs
+++ b/src/Twilio/Clients/TwilioRestClient.cs
@@ -125,6 +125,13 @@ namespace Twilio.Clients
         public async Task<Response> RequestAsync(Request request)
         {
             request.SetAuth(_username, _password);
+
+            if (Region != null)
+                request.Region = Region;
+
+            if (Edge != null)
+                request.Edge = Edge;
+
             Response response;
             try
             {

--- a/test/Twilio.Test/Clients/TwilioRestClientTest.cs
+++ b/test/Twilio.Test/Clients/TwilioRestClientTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
@@ -126,6 +127,34 @@ namespace Twilio.Tests.Clients
             twilioClient.LogLevel = "debug";
             twilioClient.Request(request);
             Assert.That(output.ToString(), Contains.Substring("request.URI: https://www.contoso.com/"));
+        }
+
+        [Test]
+        public void RequestPropagatesEdgeAndRegion()
+        {
+            client.MakeRequest(Arg.Any<Request>()).Returns(new Response(HttpStatusCode.OK, "OK"));
+            Request request = new Request(HttpMethod.Get, "https://verify.twilio.com/");
+            TwilioRestClient twilioClient = new TwilioRestClient("foo", "bar", region: "us1", httpClient: client);
+            twilioClient.Edge = "frankfurt";
+
+            twilioClient.Request(request);
+
+            Assert.AreEqual(request.Edge, "frankfurt");
+            Assert.AreEqual(request.Region, "us1");
+        }
+
+        [Test]
+        public async Task RequestAsyncPropagatesEdgeAndRegion()
+        {
+            client.MakeRequestAsync(Arg.Any<Request>()).Returns(new Response(HttpStatusCode.OK, "OK"));
+            Request request = new Request(HttpMethod.Get, "https://verify.twilio.com/");
+            TwilioRestClient twilioClient = new TwilioRestClient("foo", "bar", region: "us1", httpClient: client);
+            twilioClient.Edge = "frankfurt";
+
+            await twilioClient.RequestAsync(request);
+
+            Assert.AreEqual(request.Edge, "frankfurt");
+            Assert.AreEqual(request.Region, "us1");
         }
     }
 }

--- a/test/Twilio.Test/Clients/TwilioRestClientTest.cs
+++ b/test/Twilio.Test/Clients/TwilioRestClientTest.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Net;
 using System.Collections.Generic;
+
+#if !NET35
 using System.Threading.Tasks;
+#endif
+
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using NUnit.Framework;
@@ -143,6 +147,7 @@ namespace Twilio.Tests.Clients
             Assert.AreEqual(request.Region, "us1");
         }
 
+#if !NET35
         [Test]
         public async Task RequestAsyncPropagatesEdgeAndRegion()
         {
@@ -156,5 +161,6 @@ namespace Twilio.Tests.Clients
             Assert.AreEqual(request.Edge, "frankfurt");
             Assert.AreEqual(request.Region, "us1");
         }
+#endif
     }
 }


### PR DESCRIPTION
This PR removes behavior disparity between TwilioRestClient's Request and RequestAsync methods in terms of propagating Edge and Region properties to the request, effectively fixing RequestAsync's support for edge servers.

Fixes #565 


