### PR TITLE
fix: RequestValidator thread-safety

### DIFF
--- a/src/Twilio/Security/RequestValidator.cs
+++ b/src/Twilio/Security/RequestValidator.cs
@@ -9,7 +9,7 @@ namespace Twilio.Security
     /// <summary>
     /// Twilio request validator
     /// </summary>
-    public class RequestValidator : IDisposable
+    public class RequestValidator
     {
         private readonly string _secret;
 
@@ -167,12 +167,6 @@ namespace Twilio.Security
         {
             var startIndex = url.IndexOf(replacementString, StringComparison.OrdinalIgnoreCase);
             return url.Substring(startIndex, replacementString.Length);
-        }
-        
-        public void Dispose()
-        {
-            _hmac.Dispose()
-            _sha.Dispose();
         }
     }
 }

--- a/src/Twilio/Security/RequestValidator.cs
+++ b/src/Twilio/Security/RequestValidator.cs
@@ -9,7 +9,7 @@ namespace Twilio.Security
     /// <summary>
     /// Twilio request validator
     /// </summary>
-    public class RequestValidator
+    public class RequestValidator : IDisposable
     {
         private readonly HMACSHA1 _hmac;
         private readonly SHA256 _sha;
@@ -159,6 +159,12 @@ namespace Twilio.Security
         {
             var startIndex = url.IndexOf(replacementString, StringComparison.OrdinalIgnoreCase);
             return url.Substring(startIndex, replacementString.Length);
+        }
+        
+        public void Dispose()
+        {
+            _hmac.Dispose()
+            _sha.Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixes #466 

# Fixes #

Makes `RequestValidator` thread-safe by not holding on to instances of the crypto algos used and instead new'ing them up and disposing of them per validation.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-csharp/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
