### PR TITLE
fix: Add old `TwilioRestClient` constructor signature back for backwards compatibility

### DIFF
--- a/src/Twilio/Clients/TwilioRestClient.cs
+++ b/src/Twilio/Clients/TwilioRestClient.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Net;
 using Newtonsoft.Json;
 using Twilio.Exceptions;
@@ -51,6 +50,25 @@ namespace Twilio.Clients
         public string LogLevel { get; set; } = Environment.GetEnvironmentVariable("TWILIO_LOG_LEVEL");
         private readonly string _username;
         private readonly string _password;
+
+        /// <summary>
+        /// Constructor for a TwilioRestClient
+        /// </summary>
+        ///
+        /// <param name="username">username for requests</param>
+        /// <param name="password">password for requests</param>
+        /// <param name="accountSid">account sid to make requests for</param>
+        /// <param name="region">region to make requests for</param>
+        /// <param name="httpClient">http client used to make the requests</param>
+        public TwilioRestClient(
+            string username,
+            string password,
+            string accountSid = null,
+            string region = null,
+            HttpClient httpClient = null 
+        ) : this(username, password, accountSid, region, httpClient, null)
+        {
+        }
 
         /// <summary>
         /// Constructor for a TwilioRestClient


### PR DESCRIPTION
# Fixes #

Adds the old `TwilioRestClient` constructor signature back for backwards compatibility, which fixes #609.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-csharp/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
