### PR TITLE
fix: Patching newer versions of JwtHeader including "cty".

### DIFF
--- a/src/Twilio/JWT/BaseJwt.cs
+++ b/src/Twilio/JWT/BaseJwt.cs
@@ -73,7 +73,8 @@ namespace Twilio.Jwt
             var headers = BuildHeaders();
             foreach (var entry in Headers)
             {
-                headers.Add(entry.Key, entry.Value);
+                // Newer versions of JwtToken includes cty, which is already available in the headers.
+                headers[entry.Key] = entry.Value;
             }
 
             var payload = BuildPayload();


### PR DESCRIPTION
There are overloaded constructors that could take the header directly and sort it out.
However, they are not available in the five (!) year old System.IdentityModel.Tokens.Jwt, 5.1.2.
This seems like an easy way to deal with it and be able to upgrade beyond 6.17.0.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

Newer versions System.IdentityModel.Tokens.Jwt ( > 6.17.0 ) include cty already. The existing code causes an exception, trying to add the duplicate key. 
Newer versions of JwtHeader has an overloaded ctor, where you could pass your headers. However that constructor was not available on all packages included (5.1.2 for instance). When adopted more modern versions, a solution using the overloaded ctor and pass the headers directly would be a better one. The 3.5 implementation could simply copy the Headers or just use the same Header reference.
This seems like a viable tradeoff to solve the problem that we can't update beyond 6.17.0. 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-csharp/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
