### PR TITLE
fix: Patching newer versions of JwtHeader including "cty"

### DIFF
--- a/src/Twilio/JWT/BaseJwt.cs
+++ b/src/Twilio/JWT/BaseJwt.cs
@@ -73,7 +73,8 @@ namespace Twilio.Jwt
             var headers = BuildHeaders();
             foreach (var entry in Headers)
             {
-                headers.Add(entry.Key, entry.Value);
+                // Newer versions of JwtToken includes cty, which is already available in the headers.
+                headers[entry.Key] = entry.Value;
             }
 
             var payload = BuildPayload();

--- a/src/Twilio/Twilio.csproj
+++ b/src/Twilio/Twilio.csproj
@@ -35,8 +35,8 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.3.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.3.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.19.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.19.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

Patching newer versions of JwtHeader including "cty".
There is an overloaded constructor that could take the header directly and sort it out there.
However, it is not available in the old System.IdentityModel.Tokens.Jwt, 5.1.2.
This seems like an easy way to deal with it and be able to upgrade beyond 6.17.0.


### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/twilio/twilio-csharp/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
  * Existing test cover this.
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
