### PR TITLE
refactor: use DateTimeOffset.ToUnixTimeSeconds in BaseJwt

### DIFF
--- a/src/Twilio/JWT/BaseJwt.cs
+++ b/src/Twilio/JWT/BaseJwt.cs
@@ -153,9 +153,12 @@ namespace Twilio.Jwt
         /// <returns>seconds since epoch</returns>
         public static long ConvertToUnixTimestamp(DateTime date)
         {
+#if NET35
             var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            var utcDate = date.ToUniversalTime();
-            return Convert.ToInt64((utcDate - epoch).TotalSeconds);;
+            return Convert.ToInt64((date.ToUniversalTime() - epoch).TotalSeconds);
+#else
+            return new DateTimeOffset(date.ToUniversalTime()).ToUnixTimeSeconds();
+#endif
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded `new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)` epoch constant in `BaseJwt.ConvertToUnixTimestamp` with `DateTimeOffset.ToUnixTimeSeconds()` on modern targets
- Keep the original approach under `#if NET35` since `DateTimeOffset.ToUnixTimeSeconds` is not available on .NET 3.5
- Also fixes a stray double semicolon `;;`

## Test plan

- [ ] Build all target frameworks: `net6.0`, `netstandard2.1`, `net462`, `net35`
- [ ] Verify existing JWT-related tests pass