### PR TITLE
fix: capturing parent exception JsonException

### DIFF
--- a/src/Twilio/Clients/BearerToken/TwilioOrgsTokenRestClient.cs
+++ b/src/Twilio/Clients/BearerToken/TwilioOrgsTokenRestClient.cs
@@ -293,7 +293,7 @@ namespace Twilio.Clients.BearerToken
             {
                 restException = RestException.FromJson(response.Content);
             }
-            catch (JsonReaderException) { /* Allow null check below to handle */ }
+            catch (JsonException) { /* Allow null check below to handle */ }
 
             if (restException != null)
             {
@@ -312,7 +312,7 @@ namespace Twilio.Clients.BearerToken
             {
                 restApiStandardException = RestApiStandardException.FromJson(response.Content);
             }
-            catch (JsonReaderException) { /* Allow fallback to legacy format */ }
+            catch (JsonException) { /* Allow fallback to legacy format */ }
 
             if (restApiStandardException != null)
             {

--- a/src/Twilio/Clients/NoAuth/TwilioNoAuthRestClient.cs
+++ b/src/Twilio/Clients/NoAuth/TwilioNoAuthRestClient.cs
@@ -171,7 +171,7 @@ namespace Twilio.Clients.NoAuth
             {
                 restException = RestException.FromJson(response.Content);
             }
-            catch (JsonReaderException) { /* Allow null check below to handle */ }
+            catch (JsonException) { /* Allow null check below to handle */ }
 
 
             if (restException != null)
@@ -192,7 +192,7 @@ namespace Twilio.Clients.NoAuth
             {
                 restApiStandardException = RestApiStandardException.FromJson(response.Content);
             }
-            catch (JsonReaderException) { /* Allow fallback to legacy format */ }
+            catch (JsonException) { /* Allow fallback to legacy format */ }
 
             // Check if it's a valid RFC 9457 response (has 'type' field)
             if (restApiStandardException != null)

--- a/src/Twilio/Clients/TwilioRestClient.cs
+++ b/src/Twilio/Clients/TwilioRestClient.cs
@@ -232,7 +232,7 @@ namespace Twilio.Clients
             {
                 restException = RestException.FromJson(response.Content);
             }
-            catch (JsonReaderException) { /* Allow null check below to handle */ }
+            catch (JsonException) { /* Allow null check below to handle */ }
 
             if (restException != null)
             {
@@ -245,14 +245,14 @@ namespace Twilio.Clients
                 );
             }
 
-            
+
             // Try to deserialize as RFC 9457 format first (RestApiStandardException)
             RestApiStandardException restApiStandardException = null;
             try
             {
                 restApiStandardException = RestApiStandardException.FromJson(response.Content);
             }
-            catch (JsonReaderException) { /* Allow fallback to legacy format */ }
+            catch (JsonException) { /* Allow fallback to legacy format */ }
 
             // Check if it's a valid RFC 9457 response (has 'type' field)
             if (restApiStandardException != null)


### PR DESCRIPTION
  - Fix when API returns null for integer fields (e.g., "code": null) in error responses.